### PR TITLE
fix: dynamically truncate filenames that would exceed Windows MAX_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ When an email is archived in a folder, files are named with a zero-padded 3-digi
 - The email gets `NNN - sanitized_subject.msg`
 - Each real attachment gets `NNN - original_filename.ext`
 - Embedded images (inline in HTML body) are skipped automatically; real attachments (e.g. PDFs) are saved even when the client sets a ContentId
+- The filename is dynamically shortened with a trailing `...` if the destination folder is deep enough that the full path would otherwise exceed Windows' 260-char `MAX_PATH` limit (e.g. `042 - Long_subject_starts_here....msg`)
 
 ---
 

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -33,6 +33,11 @@ _OL_MSG_FORMAT = 3
 # Regex to find the leading NNN_ prefix in filenames
 _RE_PREFIX = re.compile(r"^(\d+)")
 
+# Windows MAX_PATH is 260; stay a few chars under to leave headroom for the OS,
+# COM marshalling, and any internal use of long-path prefixes.
+_WINDOWS_MAX_PATH = 255
+_ELLIPSIS = "..."
+
 
 # ----------------------------------------------------------------- types ----
 
@@ -55,6 +60,41 @@ def _sanitize_filename(text: str, max_len: int = 80) -> str:
     # Collapse multiple underscores/spaces
     cleaned = re.sub(r"[_ ]{2,}", "_", cleaned).strip("_. ")
     return cleaned[:max_len] if cleaned else "email"
+
+
+def _fit_filename_to_path(
+    folder_path: str,
+    seq: str,
+    stem: str,
+    suffix: str,
+    *,
+    max_path: int = _WINDOWS_MAX_PATH,
+) -> str:
+    """
+    Build ``"{seq} - {stem}{suffix}"`` such that the full path
+    ``os.path.join(folder_path, filename)`` stays within ``max_path`` chars.
+
+    If the stem has to be cut, an ellipsis is appended so the resulting
+    filename still hints at the original subject. ``suffix`` is preserved.
+    """
+    prefix = f"{seq} - "
+    sep_len = 1  # path separator inserted by os.path.join
+    filename_budget = max_path - len(folder_path) - sep_len
+    fixed = len(prefix) + len(suffix)
+
+    if filename_budget >= fixed + len(stem):
+        return f"{prefix}{stem}{suffix}"
+
+    stem_budget = filename_budget - fixed - len(_ELLIPSIS)
+    if stem_budget > 0:
+        return f"{prefix}{stem[:stem_budget]}{_ELLIPSIS}{suffix}"
+
+    # Pathological: even a one-char stem + ellipsis won't fit.
+    # Cut as tightly as possible without the ellipsis; if the folder itself
+    # already exceeds the budget there is nothing we can do except let the
+    # underlying call surface a clear OSError.
+    stem_budget = max(1, filename_budget - fixed)
+    return f"{prefix}{stem[:stem_budget]}{suffix}"
 
 
 def get_next_sequence_number(folder_path: str) -> str:
@@ -134,7 +174,7 @@ class EmailArchiver:
         subject: str,
     ) -> str:
         safe_subject = _sanitize_filename(subject)
-        filename = f"{seq} - {safe_subject}.msg"
+        filename = _fit_filename_to_path(folder_path, seq, safe_subject, ".msg")
         file_path = os.path.join(folder_path, filename)
 
         try:
@@ -196,15 +236,17 @@ class EmailArchiver:
                 original_name = attachment.FileName or f"attachment_{att_index}"
                 stem = _sanitize_filename(Path(original_name).stem, max_len=60)
                 suffix = Path(original_name).suffix.lower()
-                safe_name = stem + suffix
 
-                att_filename = f"{seq} - {safe_name}"
+                att_filename = _fit_filename_to_path(folder_path, seq, stem, suffix)
                 att_path = os.path.join(folder_path, att_filename)
-                # Avoid overwrite if multiple attachments share the same name
+                # Avoid overwrite if multiple attachments share the same name.
+                # The disambiguation suffix is folded into the stem before fitting,
+                # so the final path still respects the Windows MAX_PATH budget.
                 counter = 2
                 while os.path.exists(att_path):
-                    safe_name = f"{stem}_{counter}{suffix}"
-                    att_filename = f"{seq} - {safe_name}"
+                    att_filename = _fit_filename_to_path(
+                        folder_path, seq, f"{stem}_{counter}", suffix
+                    )
                     att_path = os.path.join(folder_path, att_filename)
                     counter += 1
 

--- a/tests/test_archiver_path_fit.py
+++ b/tests/test_archiver_path_fit.py
@@ -1,0 +1,52 @@
+"""Path-length tests for the archiver filename fitter."""
+from __future__ import annotations
+
+from email_archiver.archiver.archiver import (
+    _ELLIPSIS,
+    _WINDOWS_MAX_PATH,
+    _fit_filename_to_path,
+)
+
+
+def _full_len(folder: str, filename: str) -> int:
+    # Mirror the os.path.join + sep accounting used by the fitter.
+    return len(folder) + 1 + len(filename)
+
+
+def test_short_path_is_untouched():
+    folder = r"C:\Users\me\OneDrive\Archive\Project Alpha"
+    name = _fit_filename_to_path(folder, "042", "meeting_notes_q4", ".msg")
+    assert name == "042 - meeting_notes_q4.msg"
+    assert _full_len(folder, name) <= _WINDOWS_MAX_PATH
+
+
+def test_long_path_gets_truncated_with_ellipsis():
+    # Construct a folder that pushes the full path well past MAX_PATH.
+    folder = r"C:\Users\me\OneDrive\Archive\\" + ("nested_subdir\\" * 12) + "Final"
+    long_stem = "Quarterly_planning_meeting_with_the_extended_leadership_team_recap_attachments"
+    name = _fit_filename_to_path(folder, "007", long_stem, ".msg")
+
+    assert _full_len(folder, name) <= _WINDOWS_MAX_PATH
+    assert name.startswith("007 - ")
+    assert name.endswith(".msg")
+    # The cut portion is signposted with an ellipsis so the user can tell it's been trimmed.
+    assert _ELLIPSIS + ".msg" in name
+    # And the start of the original subject is preserved.
+    assert "Quarterly_planning" in name
+
+
+def test_truncation_preserves_extension_and_prefix():
+    folder = "C:\\" + ("x" * 230)
+    name = _fit_filename_to_path(folder, "999", "subject_text_here", ".pdf")
+    assert name.startswith("999 - ")
+    assert name.endswith(".pdf")
+    assert _full_len(folder, name) <= _WINDOWS_MAX_PATH
+
+
+def test_pathological_folder_does_not_crash():
+    # Folder alone already eats the entire budget — we should still return *something*
+    # rather than raise; the underlying SaveAs call can then fail loudly if needed.
+    folder = "C:\\" + ("x" * 280)
+    name = _fit_filename_to_path(folder, "001", "anything", ".msg")
+    assert name.startswith("001 - ")
+    assert name.endswith(".msg")


### PR DESCRIPTION
@
## Summary

Archive currently crashes when the destination folder is deep enough that `folder + "\NNN - " + 80-char-subject + ".msg"` blows past Windows 260-char `MAX_PATH` limit. The truncation logic was a fixed 80-char cap on the subject, with no awareness of the folder length.

This change adds a small `_fit_filename_to_path` helper in `email_archiver/archiver/archiver.py` that computes the available filename budget from the actual destination folder length and trims the stem with a trailing `...` so the start of the subject is preserved as a hint. Applied to both the `.msg` save and each attachment save (the collision-disambiguation counter is folded into the stem before fitting, so `_2`, `_3` suffixes cant push us back over the budget).

The behaviour is unchanged for normal short paths — the budget check is a no-op when there is room.

## Validation

- `py_compile` on the changed module — clean
- `pytest tests/ -q` — 4 passed (no-truncation, ellipsis, extension/prefix preservation, pathological folder)
- Behavioural smoke run: 172-char real-style OneDrive folder + 87-char subject → resulting full path `255` chars (== budget), filename ends in `...msg`, ellipsis present, original subject prefix preserved

## README

Added one line under *File naming convention* documenting the ellipsis behaviour.

Closes #3
@