### PR TITLE
chore: clear 5 stale audit findings (dead code + doc drift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,11 @@ archiver/
 │   │   └── archiver.py         ← File saving logic (EmailArchiver)
 │   │
 │   ├── engine/
-│   │   └── suggester.py        ← Two-stage folder ranking (SuggestionEngine)
+│   │   └── suggester.py        ← Three-stage folder ranking (SuggestionEngine)
 │   │
 │   └── ui/
 │       ├── app.py              ← ArchiveDialog, ScanWindow, LauncherApp
 │       └── dialogs.py          ← Confirm, browse, progress dialogs
-│
-├── old_refactored/              ← Original scripts kept for reference
-│   ├── email-automation-classify.py   (scanner, Excel/Pickle based)
-│   ├── email-automation-archive.py    (archiver with fuzzywuzzy suggestions)
-│   ├── email-automation-save.py       (save to active Explorer window)
-│   ├── utils.py                       (shared helpers)
-│   ├── window.py                      (Explorer window detection)
-│   ├── outlook_macros.vb              (VBA macros for Outlook)
-│   └── refactor.md                    (original design prompt, in Spanish)
 │
 ├── main_archive.py              ← Stream Deck entry: Archive Email
 ├── main_scan.py                 ← Stream Deck entry: Scan Archive
@@ -201,19 +192,23 @@ python main_ui.py
 
 ## How the suggestion engine works
 
-When you trigger "Archive Email", the app runs a two-stage ranking pipeline:
+When you trigger "Archive Email", the app runs a three-stage ranking pipeline:
 
-**Stage 1 — FTS5 full-text search (70% of final score)**
+**Stage 1 — FTS5 full-text search (45% of final score)**
 
 SQLite's built-in FTS5 engine searches the entire index of ~18,000 emails using BM25 relevance scoring. The query is built from the incoming email's subject + sender + recipients, tokenised and joined with OR so partial matches still contribute. Results are aggregated per folder (sum of per-email BM25 scores) and normalised to [0, 1].
 
 BM25 weights: subject ×10, sender ×3, recipients ×3, body preview ×1.
 
-**Stage 2 — Folder name boost (30% of final score)**
+**Stage 2 — Subject thread score (30% of final score)**
 
-`rapidfuzz.token_set_ratio` compares the email subject against the folder's leaf directory name. A folder called `Project Alpha` that matches the subject "RE: Project Alpha – Budget Q4" gets a high boost. This handles the common case where a new email in a project thread has no prior emails in the DB yet.
+`rapidfuzz.token_set_ratio` compares the incoming email's subject against the subjects of recent emails already stored in each candidate folder (up to 5 samples). A high score means the same conversation thread is already in that folder — the strongest signal for routing emails in an ongoing thread. Re:/Fwd: prefixes are handled naturally by token_set_ratio.
 
-**Final score = 0.70 × FTS_score + 0.30 × folder_name_score**
+**Stage 3 — Folder name boost (25% of final score)**
+
+`rapidfuzz.token_set_ratio` compares the email subject against the folder's leaf directory name. A folder called `Project Alpha` that matches the subject "RE: Project Alpha – Budget Q4" gets a high boost. This handles the common case where a new project thread has no prior emails in the DB yet.
+
+**Final score = 0.45 × FTS_score + 0.30 × subject_thread_score + 0.25 × folder_name_score**
 
 Up to 3 suggestions are shown, ranked by final score, each displaying the folder path, match percentage, number of similar past emails, and a sample subject from that folder.
 
@@ -286,13 +281,3 @@ WAL journal mode is enabled so the archive command can read the DB while a scan 
 | **Logging** | `print()` statements | Structured `logging` to file + console |
 | **Config** | Hardcoded `.txt` params files | `config/config.yaml` |
 
----
-
-## Notes on the old code (`old_refactored/`)
-
-The original scripts are preserved exactly as they were and are not imported or used by the new application. They serve as a reference for:
-
-- The original matching logic (`fuzz.token_set_ratio` with subject + sender + recipient scoring and `Folder_Name_Score`)
-- The `get_first_explorer_folder_path()` approach for detecting the active Windows Explorer window (used in `email-automation-save.py` to archive to the currently open folder — not replicated in the new version but available if needed)
-- The VBA macros in `outlook_macros.vb` for any Outlook-side automation
-- The original design brief in `refactor.md`

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -2,9 +2,8 @@
 Email archiver: saves .msg files and extracts attachments to disk.
 
 Naming convention (matches user spec):
-    Email:       NNN_sanitized_subject.msg
-    Attachments: NNN_01_filename.ext
-                 NNN_02_filename.ext
+    Email:       NNN - sanitized_subject.msg
+    Attachments: NNN - filename.ext
 
 Where NNN is zero-padded to 3 digits (000–999).
 

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -23,10 +23,7 @@ from typing import Any
 from email_archiver.archiver.archiver import EmailArchiver
 from email_archiver.engine.suggester import RankedSuggestion, SuggestionEngine
 from email_archiver.outlook.client import EmailData, OutlookClient
-from email_archiver.ui.dialogs import (
-    ProgressDialog,
-    browse_folder,
-)
+from email_archiver.ui.dialogs import browse_folder
 
 logger = logging.getLogger(__name__)
 

--- a/email_archiver/ui/dialogs.py
+++ b/email_archiver/ui/dialogs.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 import os
 import tkinter as tk
-from tkinter import filedialog, messagebox, ttk
-from typing import Any
+from tkinter import filedialog
 
 
 def _centre(win: tk.Toplevel | tk.Tk, w: int, h: int) -> None:
@@ -19,67 +18,6 @@ def _centre(win: tk.Toplevel | tk.Tk, w: int, h: int) -> None:
     x = (sw - w) // 2
     y = (sh - h) // 2
     win.geometry(f"{w}x{h}+{x}+{y}")
-
-
-# -------------------------------------------------------- confirm dialog ----
-
-def confirm_archive(
-    parent: tk.Misc,
-    folder_path: str,
-    email_subject: str,
-) -> str:
-    """
-    Show a confirmation dialog before archiving.
-
-    Returns:
-        "yes"         – proceed with archiving
-        "open_folder" – open the folder in Explorer, do NOT archive
-        "no"          – cancel
-    """
-    result: list[str] = ["no"]
-
-    dlg = tk.Toplevel(parent)
-    dlg.title("Confirm Archive")
-    dlg.resizable(False, False)
-    dlg.grab_set()
-    dlg.lift()
-    dlg.focus_force()
-    _centre(dlg, 780, 180)
-
-    # Message
-    msg = (
-        f"Archive email to:\n\n"
-        f"  {folder_path}\n\n"
-        f"Subject: {email_subject[:100]}"
-    )
-    tk.Label(dlg, text=msg, anchor="w", justify="left",
-             wraplength=740, padx=14, pady=10).pack(fill="x")
-
-    # Buttons
-    btn_frame = tk.Frame(dlg)
-    btn_frame.pack(pady=(0, 12))
-
-    def on_yes():
-        result[0] = "yes"
-        dlg.destroy()
-
-    def on_open():
-        result[0] = "open_folder"
-        dlg.destroy()
-
-    def on_no():
-        result[0] = "no"
-        dlg.destroy()
-
-    tk.Button(btn_frame, text="✓  Archive",  width=14, command=on_yes,
-              bg="#2d6a4f", fg="white", relief="flat", padx=6).pack(side="left", padx=5)
-    tk.Button(btn_frame, text="📂  Open Folder", width=14, command=on_open,
-              relief="flat", padx=6).pack(side="left", padx=5)
-    tk.Button(btn_frame, text="✗  Cancel",  width=10, command=on_no,
-              relief="flat", padx=6).pack(side="left", padx=5)
-
-    dlg.wait_window()
-    return result[0]
 
 
 # ------------------------------------------------------- browse dialog -----
@@ -93,78 +31,3 @@ def browse_folder(parent: tk.Misc, initial_dir: str = "") -> str | None:
         mustexist=True,
     )
     return chosen or None
-
-
-# --------------------------------------------------- progress dialog -------
-
-class ProgressDialog:
-    """
-    Non-blocking progress dialog for long-running operations (scanner).
-    Call update() from the worker thread via root.after() or directly.
-    """
-
-    def __init__(self, parent: tk.Misc, title: str = "Scanning…") -> None:
-        self._dlg = tk.Toplevel(parent)
-        self._dlg.title(title)
-        self._dlg.resizable(False, False)
-        self._dlg.grab_set()
-        _centre(self._dlg, 660, 160)
-
-        self._label = tk.Label(
-            self._dlg, text="Initialising…", anchor="w",
-            padx=14, pady=8, wraplength=630
-        )
-        self._label.pack(fill="x")
-
-        self._bar = ttk.Progressbar(
-            self._dlg, mode="determinate", length=620
-        )
-        self._bar.pack(padx=14, pady=(0, 8))
-
-        self._detail = tk.Label(
-            self._dlg, text="", anchor="w", fg="#666",
-            font=("Segoe UI", 8), padx=14, pady=2, wraplength=630
-        )
-        self._detail.pack(fill="x")
-
-        self._cancelled = False
-        btn = tk.Button(
-            self._dlg, text="Cancel", command=self._cancel,
-            relief="flat", padx=8
-        )
-        btn.pack(pady=(4, 10))
-
-        self._dlg.protocol("WM_DELETE_WINDOW", self._cancel)
-
-    def update(self, current: int, total: int, detail: str = "") -> None:
-        if total > 0:
-            pct = int(current / total * 100)
-            self._bar["value"] = pct
-            self._label.config(text=f"Indexing: {current:,} / {total:,} emails ({pct}%)")
-        else:
-            self._bar.config(mode="indeterminate")
-            self._bar.start(10)
-            self._label.config(text=f"Indexing… {current:,} emails processed")
-
-        if detail:
-            # Show only last 80 chars of a long path
-            self._detail.config(text=detail[-80:] if len(detail) > 80 else detail)
-        self._dlg.update_idletasks()
-
-    def finish(self, message: str = "Done!") -> None:
-        self._bar.stop()
-        self._bar["value"] = 100
-        self._label.config(text=message)
-        self._detail.config(text="")
-        self._dlg.update_idletasks()
-
-    def close(self) -> None:
-        self._dlg.destroy()
-
-    def _cancel(self) -> None:
-        self._cancelled = True
-        self._dlg.destroy()
-
-    @property
-    def cancelled(self) -> bool:
-        return self._cancelled


### PR DESCRIPTION
## Summary

- Deletes `confirm_archive()` dead function from `email_archiver/ui/dialogs.py` — nothing calls it; README explicitly states "no confirmation popup"
- Deletes `ProgressDialog` class from `dialogs.py` and drops its unused import from `app.py` — `ScanWindow` builds its own inline progress UI
- Removes phantom `old_refactored/` directory entry from the README project structure tree and drops the "Notes on the old code" section — the directory is not on disk or in git
- Rewrites the README "How the suggestion engine works" section to match the real 3-stage pipeline (0.45 FTS / 0.30 subject-thread / 0.25 folder-name) instead of the stale 2-stage 70/30 description
- Corrects the `archiver.py` module docstring naming convention from underscore separators (`NNN_subject.msg`) to the actual space-dash scheme (`NNN - subject.msg`)

## Validation

- Syntax: `py_compile` on all 3 changed Python files → OK
- Tests: `pytest` 4 passed, 0 failed, 0 skipped
- Diff review: changes are strictly within stated scope, no unintended files touched

Closes #7