### PR TITLE
chore: extract shared clean_subject helper into email_archiver/text.py

### DIFF
--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -13,10 +13,11 @@ Design decisions:
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
+
+from email_archiver.text import clean_subject as _clean_subject
 
 logger = logging.getLogger(__name__)
 
@@ -34,14 +35,6 @@ class EmailData:
 
 
 # -------------------------------------------------------------- helpers -----
-
-_RE_REPLY_PREFIX = re.compile(r"^\s*(re|rv|fwd?)\s*:?\s*", re.IGNORECASE)
-
-
-def _clean_subject(raw: str | None) -> str:
-    if not raw:
-        return ""
-    return _RE_REPLY_PREFIX.sub("", raw.strip()).strip()
 
 
 def _resolve_smtp(address_entry: Any) -> str:

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -25,6 +24,7 @@ from extract_msg.exceptions import InvalidFileFormatError, UnrecognizedMSGTypeEr
 
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
+from email_archiver.text import clean_subject as _clean_subject_base
 
 logger = logging.getLogger(__name__)
 
@@ -33,19 +33,9 @@ ProgressCallback = Callable[[int, int, str], None]
 
 # ---------------------------------------------------------------- helpers ---
 
-_RE_REPLY_PREFIX = re.compile(
-    r"^\s*(re|rv|fwd?)\s*:?\s*", re.IGNORECASE
-)
-_RE_MSG_SUFFIX = re.compile(r"\s*\.msg$", re.IGNORECASE)
-
-
 def _clean_subject(raw: str | None) -> str:
     """Strip Re:/Rv:/Fwd: prefixes and .msg suffix for cleaner indexing."""
-    if not raw:
-        return ""
-    s = _RE_REPLY_PREFIX.sub("", raw.strip())
-    s = _RE_MSG_SUFFIX.sub("", s)
-    return s.strip()
+    return _clean_subject_base(raw, strip_msg_suffix=True)
 
 
 def _safe_str(value: object) -> str:

--- a/email_archiver/text.py
+++ b/email_archiver/text.py
@@ -1,0 +1,39 @@
+"""
+Shared text-normalisation helpers.
+
+These utilities must stay identical on every path that processes email
+subjects — the scanner (FTS index) and the Outlook client (live email)
+both call :func:`clean_subject`, so the two sides of the app always
+agree on what "the same subject" looks like.
+"""
+from __future__ import annotations
+
+import re
+
+# Matches common reply/forward prefixes at the start of a subject line.
+RE_REPLY_PREFIX = re.compile(r"^\s*(re|rv|fwd?)\s*:?\s*", re.IGNORECASE)
+
+# Matches a trailing `.msg` filename extension.
+_RE_MSG_SUFFIX = re.compile(r"\s*\.msg$", re.IGNORECASE)
+
+
+def clean_subject(raw: str | None, *, strip_msg_suffix: bool = False) -> str:
+    """Return a normalised subject string.
+
+    Strips leading Re:/Rv:/Fwd: prefixes (case-insensitive).  When
+    *strip_msg_suffix* is ``True`` also removes a trailing ``.msg``
+    extension — useful when the subject was derived from a filename.
+
+    Args:
+        raw: The raw subject string, or ``None``/empty.
+        strip_msg_suffix: Whether to strip a trailing ``.msg`` suffix.
+
+    Returns:
+        The cleaned string, never ``None``.
+    """
+    if not raw:
+        return ""
+    s = RE_REPLY_PREFIX.sub("", raw.strip())
+    if strip_msg_suffix:
+        s = _RE_MSG_SUFFIX.sub("", s)
+    return s.strip()


### PR DESCRIPTION
## Summary

- Extract the duplicated subject-cleaning logic (regex + function) from `email_archiver/outlook/client.py` and `email_archiver/scanner/scanner.py` into a new shared module `email_archiver/text.py`
- New public API: `clean_subject(raw, *, strip_msg_suffix=False)` — the scanner passes `strip_msg_suffix=True` to preserve its `.msg`-stripping behaviour; the Outlook client calls it with the default
- Both sides of the app (FTS index builder and live-archive path) now share one normalisation path, preventing silent divergence when reply-prefix detection changes

## Validation

- `py_compile email_archiver/text.py email_archiver/outlook/client.py email_archiver/scanner/scanner.py` — OK
- `pytest` — 4 passed, 0 failed, 0 skipped
- Inline behavioural probe covering all prefix variants (Re:, Fwd:, Rv:, fw:, mixed case, leading spaces), None/empty input, and `.msg`-suffix stripping with/without the flag — all pass

Closes #10
