### PR TITLE
refactor: dedupe archive-root resolution and folder display name

### DIFF
--- a/email_archiver/config.py
+++ b/email_archiver/config.py
@@ -38,6 +38,22 @@ def load_config() -> dict[str, Any]:
     return _config
 
 
+def get_archive_roots(cfg: dict[str, Any]) -> list[str]:
+    """Return the configured archive root paths.
+
+    Reads the canonical ``archive.root_paths`` list, falling back to the
+    legacy singular ``archive.root_path`` key when ``root_paths`` is absent.
+    This migration shim lives here and nowhere else — every caller (scanner,
+    UI, headless scan) goes through this function so the legacy-key handling
+    is defined exactly once. Falsy/empty entries are filtered out.
+    """
+    archive = cfg["archive"]
+    raw_paths = archive.get("root_paths")
+    if not raw_paths:
+        raw_paths = [archive.get("root_path")]
+    return [p for p in raw_paths if p]
+
+
 def _resolve_paths(cfg: dict[str, Any]) -> None:
     """Convert relative paths in the config to absolute paths."""
     db_path = Path(cfg["database"]["path"])

--- a/email_archiver/engine/suggester.py
+++ b/email_archiver/engine/suggester.py
@@ -32,7 +32,6 @@ Fallback (empty DB):
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -58,10 +57,18 @@ class RankedSuggestion:
 
 
 def _folder_display_name(path: str) -> str:
-    """Return the last two components of a path for display."""
-    parts = Path(path).parts
+    """Return the last two components of a path for display.
+
+    Components are joined with a forward slash regardless of platform so the
+    string renders identically in logs and in the UI (which displays archive
+    paths with ``/`` separators). This is the single source of truth for the
+    compact "last two components" form — the UI uses ``RankedSuggestion.
+    display_name`` rather than recomputing it.
+    """
+    parts = path.replace("\\", "/").split("/")
+    parts = [p for p in parts if p]
     if len(parts) >= 2:
-        return os.path.join(parts[-2], parts[-1])
+        return "/".join(parts[-2:])
     return parts[-1] if parts else path
 
 

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -22,6 +22,7 @@ from typing import Callable
 import extract_msg
 from extract_msg.exceptions import InvalidFileFormatError, UnrecognizedMSGTypeError
 
+from email_archiver.config import get_archive_roots
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
 from email_archiver.text import clean_subject as _clean_subject_base
@@ -106,10 +107,7 @@ class FolderScanner:
     """
 
     def __init__(self, cfg: dict) -> None:
-        raw_paths = cfg["archive"].get("root_paths")
-        if not raw_paths:
-            raw_paths = [cfg["archive"].get("root_path")]
-        self._roots = [Path(p) for p in raw_paths if p]
+        self._roots = [Path(p) for p in get_archive_roots(cfg)]
         self._db_path = cfg["database"]["path"]
         self._batch_size: int = cfg["scanning"]["batch_size"]
         self._preview_len: int = cfg["scanning"]["body_preview_length"]

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -21,6 +21,7 @@ from tkinter import messagebox, ttk
 from typing import Any
 
 from email_archiver.archiver.archiver import EmailArchiver
+from email_archiver.config import get_archive_roots
 from email_archiver.engine.suggester import RankedSuggestion, SuggestionEngine
 from email_archiver.outlook.client import EmailData, OutlookClient
 from email_archiver.ui.dialogs import browse_folder
@@ -220,9 +221,11 @@ class ArchiveDialog:
             )
             rank_lbl.grid(row=0, column=0, rowspan=2, sticky="ns", padx=(0, 8))
 
-            # Folder path (last 2 components bold, rest grey)
-            path_parts = s.folder_path.replace("\\", "/").split("/")
-            short = "/".join(path_parts[-2:]) if len(path_parts) >= 2 else s.folder_path
+            # Folder path: last 2 components bold (from the engine's canonical
+            # display_name), the rest a grey prefix. Only the grey-prefix split
+            # is UI-specific styling — the compact tail is the engine's value.
+            short = s.display_name
+            path_parts = [p for p in s.folder_path.replace("\\", "/").split("/") if p]
             rest = "/".join(path_parts[:-2]) + "/" if len(path_parts) > 2 else ""
 
             path_frame = tk.Frame(card, bg=_CARD_BG)
@@ -289,7 +292,8 @@ class ArchiveDialog:
     # ------------------------------------------------ user interactions ----
 
     def _on_browse(self) -> None:
-        archive_root = self._cfg["archive"].get("root_paths", [self._cfg["archive"].get("root_path")])[0]
+        roots = get_archive_roots(self._cfg)
+        archive_root = roots[0] if roots else None
         chosen = browse_folder(self._root, initial_dir=archive_root)
         if chosen:
             self._do_archive(chosen)
@@ -370,7 +374,7 @@ class ScanWindow:
         tk.Label(hdr, text="🗂  Scan Archive", bg=_ACCENT, fg="white",
                  font=(ff, ft, "bold"), padx=16).pack(side="left")
 
-        roots = self._cfg['archive'].get('root_paths', [self._cfg['archive'].get('root_path')])
+        roots = get_archive_roots(self._cfg)
         text = "Archive roots:\n" + "\n".join(str(r) for r in roots)
         info = tk.Label(
             root,

--- a/main_scan.py
+++ b/main_scan.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from email_archiver.config import load_config, setup_logging
+from email_archiver.config import get_archive_roots, load_config, setup_logging
 
 
 def main() -> None:
@@ -44,7 +44,7 @@ def _run_headless(cfg: dict) -> None:
             pct = f"{int(current / total * 100)}%" if total else ""
             print(f"\r  {current:>6,} / {total:,}  {pct}  ", end="", flush=True)
 
-    roots = cfg['archive'].get('root_paths', [cfg['archive'].get('root_path')])
+    roots = get_archive_roots(cfg)
     logger.info("Scanning: %s", roots)
     stats = scanner.scan(progress_callback=on_progress)
     print()  # clear the \r progress line


### PR DESCRIPTION
## Summary

Clears the two duplication findings in #13.

- **Finding 1 — legacy-key shim copied 4×:** new `get_archive_roots(cfg) -> list[str]` helper in `config.py`. The `root_path` (singular) → `root_paths` migration now lives in exactly one place; `scanner`, `ui/app` (browse + scan window), and `main_scan` all import it. Also guards `_on_browse` against an empty roots list.
- **Finding 2 — display-name drift:** kept `RankedSuggestion.display_name` (it is *not* dead — the engine uses it in its log line at `suggester.py:176`). Made the engine's `_folder_display_name` the single source of the compact "last two components" string, normalized to `/` to kill the separator drift. The UI now uses `s.display_name` for its bold segment and computes only the grey path prefix locally (genuine UI styling). Dropped the now-unused `os` import.

## Validation

`py_compile` on all 5 changed files (pass) + `pytest -q` → 4 passed.

Closes #13