### PR TITLE
refactor: unify max-path-length on one config-sourced value

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -18,7 +18,13 @@ database:
 scanning:
   batch_size: 500
   body_preview_length: 500
-  max_path_length: 259
+
+path:
+  # Maximum path length (chars) honoured by BOTH the scanner (skips existing
+  # paths longer than this) and the archiver (shortens filenames so the path it
+  # writes never overflows). Windows MAX_PATH is 260 incl. the terminating NUL;
+  # 255 leaves headroom for the OS, COM marshalling, and long-path prefixes.
+  max_length: 255
 
 suggestion:
   max_suggestions: 3

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from email_archiver.config import DEFAULT_MAX_PATH_LENGTH, get_max_path_length
+
 logger = logging.getLogger(__name__)
 
 # Outlook SaveAs format constant for .msg
@@ -32,9 +34,10 @@ _OL_MSG_FORMAT = 3
 # Regex to find the leading NNN_ prefix in filenames
 _RE_PREFIX = re.compile(r"^(\d+)")
 
-# Windows MAX_PATH is 260; stay a few chars under to leave headroom for the OS,
-# COM marshalling, and any internal use of long-path prefixes.
-_WINDOWS_MAX_PATH = 255
+# Maximum path length (in chars) the fitted filename must stay within. This is
+# the SAME budget the scanner uses — sourced from config via
+# ``get_max_path_length`` and threaded in through ``EmailArchiver``; see
+# ``config.DEFAULT_MAX_PATH_LENGTH`` for the rationale behind the value.
 _ELLIPSIS = "..."
 
 
@@ -67,7 +70,7 @@ def _fit_filename_to_path(
     stem: str,
     suffix: str,
     *,
-    max_path: int = _WINDOWS_MAX_PATH,
+    max_path: int = DEFAULT_MAX_PATH_LENGTH,
 ) -> str:
     """
     Build ``"{seq} - {stem}{suffix}"`` such that the full path
@@ -124,6 +127,18 @@ def get_next_sequence_number(folder_path: str) -> str:
 class EmailArchiver:
     """Saves an Outlook MailItem (COM object) to a target folder on disk."""
 
+    def __init__(self, cfg: dict[str, Any] | None = None) -> None:
+        """Build an archiver bound to a path-length budget.
+
+        ``cfg`` is the loaded config dict; the path budget is read from it via
+        the shared ``get_max_path_length`` accessor so the archiver and scanner
+        honour the same ``path.max_length`` knob. When ``cfg`` is omitted the
+        ``DEFAULT_MAX_PATH_LENGTH`` fallback is used.
+        """
+        self._max_path: int = (
+            get_max_path_length(cfg) if cfg is not None else DEFAULT_MAX_PATH_LENGTH
+        )
+
     def archive(
         self,
         mail_item: Any,
@@ -173,7 +188,9 @@ class EmailArchiver:
         subject: str,
     ) -> str:
         safe_subject = _sanitize_filename(subject)
-        filename = _fit_filename_to_path(folder_path, seq, safe_subject, ".msg")
+        filename = _fit_filename_to_path(
+            folder_path, seq, safe_subject, ".msg", max_path=self._max_path
+        )
         file_path = os.path.join(folder_path, filename)
 
         try:
@@ -236,7 +253,9 @@ class EmailArchiver:
                 stem = _sanitize_filename(Path(original_name).stem, max_len=60)
                 suffix = Path(original_name).suffix.lower()
 
-                att_filename = _fit_filename_to_path(folder_path, seq, stem, suffix)
+                att_filename = _fit_filename_to_path(
+                    folder_path, seq, stem, suffix, max_path=self._max_path
+                )
                 att_path = os.path.join(folder_path, att_filename)
                 # Avoid overwrite if multiple attachments share the same name.
                 # The disambiguation suffix is folded into the stem before fitting,
@@ -244,7 +263,8 @@ class EmailArchiver:
                 counter = 2
                 while os.path.exists(att_path):
                     att_filename = _fit_filename_to_path(
-                        folder_path, seq, f"{stem}_{counter}", suffix
+                        folder_path, seq, f"{stem}_{counter}", suffix,
+                        max_path=self._max_path,
                     )
                     att_path = os.path.join(folder_path, att_filename)
                     counter += 1

--- a/email_archiver/config.py
+++ b/email_archiver/config.py
@@ -16,6 +16,14 @@ import yaml
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 CONFIG_FILE = PROJECT_ROOT / "config" / "config.yaml"
 
+# Windows MAX_PATH is 260 (including the terminating NUL → 259 usable chars).
+# We stay a few chars under to leave headroom for the OS, COM marshalling, and
+# any internal use of long-path prefixes. This single budget is consumed by
+# BOTH the scanner (skips over-long existing paths) and the archiver (shortens
+# filenames so the path it writes never overflows). Used when config omits the
+# key so older config.yaml files keep working.
+DEFAULT_MAX_PATH_LENGTH = 255
+
 _config: dict[str, Any] | None = None
 
 
@@ -52,6 +60,23 @@ def get_archive_roots(cfg: dict[str, Any]) -> list[str]:
     if not raw_paths:
         raw_paths = [archive.get("root_path")]
     return [p for p in raw_paths if p]
+
+
+def get_max_path_length(cfg: dict[str, Any]) -> int:
+    """Return the unified maximum path-length budget (in chars).
+
+    Reads the canonical ``path.max_length`` key, falling back to
+    ``DEFAULT_MAX_PATH_LENGTH`` when the section/key is absent so older
+    ``config.yaml`` files (and the legacy ``scanning.max_path_length`` layout)
+    keep working. Both the scanner and the archiver go through this function so
+    the budget is defined in exactly one place — never split across a config
+    value and a module constant again.
+    """
+    path_cfg = cfg.get("path") or {}
+    value = path_cfg.get("max_length")
+    if value is None:
+        return DEFAULT_MAX_PATH_LENGTH
+    return int(value)
 
 
 def _resolve_paths(cfg: dict[str, Any]) -> None:

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -22,7 +22,7 @@ from typing import Callable
 import extract_msg
 from extract_msg.exceptions import InvalidFileFormatError, UnrecognizedMSGTypeError
 
-from email_archiver.config import get_archive_roots
+from email_archiver.config import get_archive_roots, get_max_path_length
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
 from email_archiver.text import clean_subject as _clean_subject_base
@@ -111,7 +111,7 @@ class FolderScanner:
         self._db_path = cfg["database"]["path"]
         self._batch_size: int = cfg["scanning"]["batch_size"]
         self._preview_len: int = cfg["scanning"]["body_preview_length"]
-        self._max_path: int = cfg["scanning"]["max_path_length"]
+        self._max_path: int = get_max_path_length(cfg)
 
     def scan(
         self,

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -326,7 +326,7 @@ class ArchiveDialog:
                 messagebox.showerror("Outlook error", f"Cannot access Outlook:\n{exc}")
                 return
 
-            archiver = EmailArchiver()
+            archiver = EmailArchiver(self._cfg)
             result = archiver.archive(
                 mail_item=mail_item,
                 folder_path=folder_path,

--- a/tests/test_archiver_path_fit.py
+++ b/tests/test_archiver_path_fit.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from email_archiver.archiver.archiver import (
     _ELLIPSIS,
-    _WINDOWS_MAX_PATH,
     _fit_filename_to_path,
 )
+from email_archiver.config import DEFAULT_MAX_PATH_LENGTH as _WINDOWS_MAX_PATH
 
 
 def _full_len(folder: str, filename: str) -> int:


### PR DESCRIPTION
## Summary

Resolves #8 — the project had two disagreeing notions of "max Windows path length": the scanner read `scanning.max_path_length: 259` from config, while the archiver used a hardcoded `_WINDOWS_MAX_PATH = 255` module constant, so tuning the config knob silently had no effect on the archiver's filename-fitting.

- Add `config.DEFAULT_MAX_PATH_LENGTH = 255` + a `get_max_path_length(cfg)` accessor (mirrors the existing `get_archive_roots` shim).
- Scanner and archiver now both source the budget via `get_max_path_length(cfg)` — the scanner drops its direct config-key read, the archiver drops the hardcoded constant and binds `self._max_path` from config, threading it through both `_fit_filename_to_path` call sites. `ui/app.py` passes `cfg` into `EmailArchiver`.
- Relocate the knob from `scanning.max_path_length` to a new top-level `path.max_length` section, since **both** the scanner and archiver consume it (it doesn't belong under `scanning`).
- **Unified value is 255**, not 259: the archiver *writes* files, so an overflow is a hard failure; 255 stays under Windows' 260 `MAX_PATH` for OS / COM / long-path headroom. The scanner only read-filters, so the stricter limit is safe there too.

## Validation

`& .\.venv\Scripts\python.exe -m pytest` → **4 passed**. (No ruff configured in this repo.) Wiring smoke-test confirms the new `path.max_length` key, the legacy `scanning.max_path_length`, and an absent config all resolve correctly to the unified budget.

Closes #8