### PR TITLE
docs: correct dialogs.py description in README project-structure block

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ archiver/
 │   │
 │   └── ui/
 │       ├── app.py              ← ArchiveDialog, ScanWindow, LauncherApp
-│       └── dialogs.py          ← Confirm, browse, progress dialogs
+│       └── dialogs.py          ← Native folder-picker wrapper
 │
 ├── main_archive.py              ← Stream Deck entry: Archive Email
 ├── main_scan.py                 ← Stream Deck entry: Scan Archive


### PR DESCRIPTION
## Summary

- README.md line 90 described `dialogs.py` as `← Confirm, browse, progress dialogs`, but the confirm and progress dialogs were removed — the file now only exports `browse_folder` (a thin wrapper around `filedialog.askdirectory`).
- One-line fix: rewrite the description to `← Native folder-picker wrapper`, matching what the file actually exports.

## Validation

- `py_compile` on `email_archiver/ui/dialogs.py` and `email_archiver/ui/app.py`: pass
- `git diff main..HEAD`: exactly one line changed in `README.md`, nothing else touched
- No CI workflows in this repo — docs-only change, merged immediately
- No tests exist in this repo; no test changes made

Closes #20