### PR TITLE
chore: invoke venv pythonw.exe directly in Stream Deck launchers

### DIFF
--- a/launch_archive.bat
+++ b/launch_archive.bat
@@ -7,11 +7,6 @@ set "SCRIPT_DIR=%~dp0"
 set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 set "VENV_DIR=%SCRIPT_DIR%\.venv"
 
-REM Activate virtual environment if it exists
-if exist "%VENV_DIR%\Scripts\activate.bat" (
-    call "%VENV_DIR%\Scripts\activate.bat"
-)
-
 REM Ensure we run from project root so config and imports resolve
 cd /d "%SCRIPT_DIR%"
 if errorlevel 1 (
@@ -21,4 +16,4 @@ if errorlevel 1 (
 )
 
 REM Start Python without console; use /d so the child process has correct cwd
-start "" /d "%SCRIPT_DIR%" pythonw main_archive.py
+start "" /d "%SCRIPT_DIR%" "%VENV_DIR%\Scripts\pythonw.exe" main_archive.py

--- a/launch_scan.bat
+++ b/launch_scan.bat
@@ -7,11 +7,6 @@ set "SCRIPT_DIR=%~dp0"
 set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 set "VENV_DIR=%SCRIPT_DIR%\.venv"
 
-REM Activate virtual environment if it exists
-if exist "%VENV_DIR%\Scripts\activate.bat" (
-    call "%VENV_DIR%\Scripts\activate.bat"
-)
-
 REM Ensure we run from project root so config and imports resolve
 cd /d "%SCRIPT_DIR%"
 if errorlevel 1 (
@@ -21,4 +16,4 @@ if errorlevel 1 (
 )
 
 REM Start Python without console; use /d so the child process has correct cwd
-start "" /d "%SCRIPT_DIR%" pythonw main_scan.py
+start "" /d "%SCRIPT_DIR%" "%VENV_DIR%\Scripts\pythonw.exe" main_scan.py


### PR DESCRIPTION
## Summary

- Drop the `call activate.bat` block from both `launch_archive.bat` and `launch_scan.bat` — activation is explicitly forbidden by CLAUDE.md
- Replace bare `pythonw` with `"%VENV_DIR%\Scripts\pythonw.exe"` so the correct venv interpreter is always resolved by absolute path, independent of PATH ordering or whether `activate.bat` exists

## Validation

- **Diff scope:** only `launch_archive.bat` and `launch_scan.bat` changed — exactly the two files named in the issue
- **No Python changed** — no py_compile/ruff needed
- **No test suite** exists in this repo (CLAUDE.md: "say so explicitly")
- **Behavioural check:** `.venv\Scripts\pythonw.exe` confirmed present on disk — the new absolute-path invocation resolves correctly
- **No README change needed** — internal launcher detail, not a usage/config surface

Closes #19