### PR TITLE
chore: remove dead _centre() and fix stale module docstring in dialogs.py

### DIFF
--- a/email_archiver/ui/dialogs.py
+++ b/email_archiver/ui/dialogs.py
@@ -1,8 +1,8 @@
 """
 Reusable Tkinter dialog helpers.
 
-All dialogs are modal (grab_set) and centred on screen.
-They block until the user closes them and return a result value.
+Exports a single helper, ``browse_folder``, which wraps the native
+``filedialog.askdirectory`` call with sensible defaults.
 """
 from __future__ import annotations
 
@@ -10,17 +10,6 @@ import os
 import tkinter as tk
 from tkinter import filedialog
 
-
-def _centre(win: tk.Toplevel | tk.Tk, w: int, h: int) -> None:
-    win.update_idletasks()
-    sw = win.winfo_screenwidth()
-    sh = win.winfo_screenheight()
-    x = (sw - w) // 2
-    y = (sh - h) // 2
-    win.geometry(f"{w}x{h}+{x}+{y}")
-
-
-# ------------------------------------------------------- browse dialog -----
 
 def browse_folder(parent: tk.Misc, initial_dir: str = "") -> str | None:
     """Open a native folder-picker dialog. Returns the selected path or None."""


### PR DESCRIPTION
## Summary

- Deletes the `_centre()` helper function in `email_archiver/ui/dialogs.py`, which was defined but never called anywhere in the repo (orphaned dead code from when the module contained hand-rolled Tkinter dialogs).
- Rewrites the module docstring, which claimed all dialogs use `grab_set` and centre on screen — a description of the removed dialogs, not of the current sole export `browse_folder`.

## Validation

- `py_compile email_archiver/ui/dialogs.py` — OK
- `pytest tests/` — 4/4 passed
- `git diff main...HEAD` reviewed — only the two items from the issue, nothing else changed
- No CI workflows exist in this repo; no tray to restart.

Closes #18