### PR TITLE
docs: add text.py to README project structure block

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ archiver/
 │
 ├── email_archiver/              ← Main package
 │   ├── config.py                ← YAML loader, path resolution, logging setup
+│   ├── text.py                  ← Shared subject normalisation (Re:/Fwd: stripping)
 │   │
 │   ├── database/
 │   │   ├── models.py            ← SQLite schema, FTS5 setup, connection factory


### PR DESCRIPTION
## Summary

- `text.py` (shared subject normalisation — `Re:`/`Fwd:` stripping) was present in `email_archiver/` but absent from the project structure tree in `README.md`.
- Added a single line alongside `config.py` matching the format of all surrounding entries.

## Validation

- 3f diff sweep: exactly one line added to `README.md`, no other files touched.
- No `.github/workflows/` in this repo — CI not awaited (docs-only change, no docs CI job).

Closes #29