### PR TITLE
refactor: extract shared get_selected_mail_item helper

### DIFF
--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -98,6 +98,22 @@ def _get_recipients_smtp(mail_item: Any) -> str:
 
 # ------------------------------------------------------------- client ------
 
+
+def get_selected_mail_item() -> Any | None:
+    """
+    Return the currently selected Outlook MailItem via COM, or None if
+    nothing is selected. Raises on COM errors so the caller can surface
+    them appropriately.
+    """
+    import win32com.client  # noqa: PLC0415
+    app = win32com.client.GetActiveObject("Outlook.Application")
+    explorer = app.ActiveExplorer()
+    if explorer is None or explorer.Selection.Count == 0:
+        return None
+    # Dispatch forces full COM interface resolution → MailItem with SaveAs
+    return win32com.client.Dispatch(explorer.Selection.Item(1))
+
+
 class OutlookClient:
     """
     Wraps Outlook COM automation.
@@ -148,28 +164,16 @@ class OutlookClient:
             return None
 
         try:
-            app = win32com.client.GetActiveObject("Outlook.Application")
+            item = get_selected_mail_item()
         except Exception as exc:
-            logger.error("Cannot connect to running Outlook instance: %s", exc)
+            logger.error("Cannot access Outlook or selection: %s", exc)
+            return None
+
+        if item is None:
+            logger.warning("No email selected in Outlook.")
             return None
 
         try:
-            explorer = app.ActiveExplorer()
-            if explorer is None:
-                logger.warning("No active Outlook explorer window.")
-                return None
-
-            selection = explorer.Selection
-            if selection.Count == 0:
-                logger.warning("No email selected in Outlook.")
-                return None
-
-            # Dispatch forces win32com to resolve the full COM interface for
-            # this object. Without it, late-bound dynamic dispatch returns a
-            # generic Item wrapper that lacks MailItem-specific methods like
-            # SaveAs, which causes AttributeError: Item.SaveAs at archive time.
-            item = win32com.client.Dispatch(selection.Item(1))
-
             # Ensure it is a MailItem (Class == 43)
             if item.Class != 43:
                 logger.warning(

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -23,7 +23,7 @@ from typing import Any
 from email_archiver.archiver.archiver import EmailArchiver
 from email_archiver.config import get_archive_roots
 from email_archiver.engine.suggester import RankedSuggestion, SuggestionEngine
-from email_archiver.outlook.client import EmailData, OutlookClient
+from email_archiver.outlook.client import EmailData, OutlookClient, get_selected_mail_item
 from email_archiver.ui.dialogs import browse_folder
 
 logger = logging.getLogger(__name__)
@@ -310,18 +310,14 @@ class ArchiveDialog:
             # The user's selection in Outlook won't have changed between
             # seeing suggestions and clicking Archive.
             import pythoncom
-            import win32com.client as _win32
 
             pythoncom.CoInitialize()
 
             try:
-                app = _win32.GetActiveObject("Outlook.Application")
-                explorer = app.ActiveExplorer()
-                if explorer is None or explorer.Selection.Count == 0:
+                mail_item = get_selected_mail_item()
+                if mail_item is None:
                     messagebox.showerror("Error", "No email is selected in Outlook.")
                     return
-                # Dispatch forces full COM interface resolution → MailItem with SaveAs
-                mail_item = _win32.Dispatch(explorer.Selection.Item(1))
             except Exception as exc:
                 messagebox.showerror("Outlook error", f"Cannot access Outlook:\n{exc}")
                 return


### PR DESCRIPTION
## Summary

- Adds `get_selected_mail_item()` as a module-level function in `email_archiver/outlook/client.py`, encapsulating the duplicated COM acquisition sequence (`GetActiveObject` → `ActiveExplorer` → `Selection.Count` guard → `Dispatch(Selection.Item(1))`) in one place.
- `OutlookClient.get_selected_email()` now delegates to the helper for item acquisition; the MailItem class check and all metadata extraction are unchanged.
- `ArchiveDialog._do_archive()` now calls `get_selected_mail_item()` instead of re-importing `win32com.client` and re-running the acquisition inline.
- The STA thread-boundary re-acquisition is **preserved**: `app.py` still calls the helper itself from the main UI thread, after `CoInitialize()`. Only the acquisition *steps* are shared, not the call.
- Restores the COM-isolation invariant stated in `client.py:6`: `win32com` is no longer imported outside `outlook/client.py`.

## Test plan

- [x] `py_compile` on both changed files — no syntax errors
- [x] `pytest tests/` — 4/4 passed

Closes #27