### PR TITLE
refactor: delete dead EmailRepository.get_all_folder_paths method

### DIFF
--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -265,13 +265,6 @@ class EmailRepository:
 
         return suggestions[:max_results]
 
-    def get_all_folder_paths(self) -> list[str]:
-        """Return all indexed folder paths (used by suggestion engine fallback)."""
-        rows = self._conn.execute(
-            "SELECT folder_path FROM folders ORDER BY email_count DESC"
-        ).fetchall()
-        return [r["folder_path"] for r in rows]
-
     def get_last_scan_time(self) -> str:
         """Return ISO datetime of the most recent indexing operation."""
         row = self._conn.execute(


### PR DESCRIPTION
## Summary

- Deletes `EmailRepository.get_all_folder_paths()` (lines 268-273 in `repository.py`) — a method with zero callers anywhere in the codebase.
- The docstring claimed it was "used by suggestion engine fallback", but `SuggestionEngine.suggest()` returns `[]` on empty FTS results and never enumerates all folder paths; the fallback was never built.

## Validation

- `py_compile email_archiver/database/repository.py` — clean
- `pytest tests/ -v` — 4/4 passed (no skips)
- `git diff main...HEAD` — only the 7 deleted lines; nothing outside stated scope

Closes #28