### PR TITLE
fix: outlook client.py tasklist call missing CREATE_NO_WINDOW

### DIFF
--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -138,10 +138,12 @@ class OutlookClient:
 
         # Fallback: subprocess tasklist (slower but no extra dep)
         import subprocess
+        import sys
         try:
             result = subprocess.run(
                 ["tasklist", "/FI", "IMAGENAME eq OUTLOOK.EXE", "/NH"],
-                capture_output=True, text=True, timeout=5
+                capture_output=True, text=True, timeout=5,
+                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
             return "OUTLOOK.EXE" in result.stdout.upper()
         except Exception:


### PR DESCRIPTION
## Summary
- `OutlookClient.is_running()`'s `psutil`-less fallback spawned `tasklist` via `subprocess.run` without `creationflags=subprocess.CREATE_NO_WINDOW`, flashing a visible console window on Windows.
- Part of the fleet-wide subprocess console-window sweep tracked in ferraroroberto/fleet-config#399.

Closes #35

## Validation
- [x] `python -m py_compile email_archiver/outlook/client.py` — passes
- [x] `python -m pytest tests/` — 4 passed