### PR TITLE
chore: ignore launcher-tmp scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 .venv/
 venv/
 tmp/
+# Launcher scratch (ephemeral images/logs written by the tray launcher)
+.launcher-tmp/


### PR DESCRIPTION
Backfill .launcher-tmp/ into the .gitignore so the app-launcher session host's ephemeral upload scratch dir doesn't get tracked when a session is rooted here.

Part of ferraroroberto/fleet-config#496