### PR TITLE
fix: pin OEM decoding for the tasklist Outlook check

### DIFF
--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -96,6 +96,56 @@ def _get_recipients_smtp(mail_item: Any) -> str:
     return "; ".join(a for a in addresses if a)
 
 
+def _tasklist_has_image(image_name: str) -> bool:
+    """
+    Return True if `image_name` (e.g. "OUTLOOK.EXE") appears in the Windows
+    process list, using the `tasklist` console tool.
+
+    A failed query is *not* the same fact as "the process is not running", so
+    every failure is logged before falling back to False — otherwise a broken
+    query is indistinguishable from a quiet machine.
+    """
+    import subprocess  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    is_windows = sys.platform == "win32"
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", f"IMAGENAME eq {image_name}", "/NH"],
+            capture_output=True, timeout=5,
+            # tasklist writes the OEM code page, not the parent's locale.
+            # text=True decodes with the ambient locale, which under
+            # PYTHONUTF8=1 is UTF-8: the OEM bytes then fail to decode, stdout
+            # comes back None, and the result silently reads as "not running".
+            encoding="oem" if is_windows else "utf-8",
+            errors="replace",
+            creationflags=subprocess.CREATE_NO_WINDOW if is_windows else 0,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning(
+            "Could not run tasklist to check for %s (%s: %s) - "
+            "treating as not running.", image_name, type(exc).__name__, exc,
+        )
+        return False
+
+    if result.returncode != 0:
+        logger.warning(
+            "tasklist exited %s while checking for %s (%s) - "
+            "treating as not running.",
+            result.returncode, image_name, (result.stderr or "").strip(),
+        )
+        return False
+
+    if not (result.stdout or "").strip():
+        logger.warning(
+            "tasklist returned no output while checking for %s - cannot tell "
+            "whether it is running; treating as not running.", image_name,
+        )
+        return False
+
+    return image_name.upper() in result.stdout.upper()
+
+
 # ------------------------------------------------------------- client ------
 
 
@@ -137,17 +187,7 @@ class OutlookClient:
             pass
 
         # Fallback: subprocess tasklist (slower but no extra dep)
-        import subprocess
-        import sys
-        try:
-            result = subprocess.run(
-                ["tasklist", "/FI", "IMAGENAME eq OUTLOOK.EXE", "/NH"],
-                capture_output=True, text=True, timeout=5,
-                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
-            )
-            return "OUTLOOK.EXE" in result.stdout.upper()
-        except Exception:
-            return False
+        return _tasklist_has_image("OUTLOOK.EXE")
 
     def get_selected_email(self) -> EmailData | None:
         """

--- a/tests/test_outlook_is_running.py
+++ b/tests/test_outlook_is_running.py
@@ -1,0 +1,196 @@
+"""
+Tests for the `tasklist` fallback behind OutlookClient.is_running().
+
+The fallback shells out to a native Windows console tool, which writes the OEM
+code page rather than the parent's locale. Decoding it with `text=True` breaks
+the moment the parent runs in UTF-8 mode (PYTHONUTF8=1): stdout comes back
+None and a running Outlook is silently reported as not running. See issue #38.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from email_archiver.outlook import client as client_mod
+from email_archiver.outlook.client import OutlookClient, _tasklist_has_image
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+IS_WINDOWS = sys.platform == "win32"
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str | None = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _capture_run(monkeypatch, result: _FakeCompleted | Exception) -> dict:
+    """Replace subprocess.run and return the dict its kwargs land in."""
+    seen: dict = {}
+
+    def fake_run(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return seen
+
+
+# ------------------------------------------------------------ decoding -----
+
+
+def test_tasklist_pins_its_own_decoding(monkeypatch):
+    """The call must never inherit the ambient locale via text=True."""
+    seen = _capture_run(monkeypatch, _FakeCompleted(stdout="OUTLOOK.EXE  1234 Console\n"))
+
+    assert _tasklist_has_image("OUTLOOK.EXE") is True
+
+    kwargs = seen["kwargs"]
+    assert "text" not in kwargs
+    assert "universal_newlines" not in kwargs
+    assert kwargs["errors"] == "replace"
+    assert kwargs["encoding"] == ("oem" if IS_WINDOWS else "utf-8")
+    assert kwargs["capture_output"] is True
+    assert kwargs["timeout"] == 5
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="CREATE_NO_WINDOW is Windows-only")
+def test_tasklist_keeps_console_window_suppressed(monkeypatch):
+    """A console-less parent must not get a window flashed at it per spawn."""
+    seen = _capture_run(monkeypatch, _FakeCompleted(stdout="INFO: No tasks\n"))
+
+    _tasklist_has_image("OUTLOOK.EXE")
+
+    assert seen["kwargs"]["creationflags"] == subprocess.CREATE_NO_WINDOW
+
+
+# ------------------------------------------------- failed query is loud -----
+
+
+def test_no_match_is_quiet(monkeypatch, caplog):
+    """A successful query that found nothing is a fact, not a failure."""
+    _capture_run(monkeypatch, _FakeCompleted(
+        stdout="INFO: No tasks are running which match the specified criteria.\n"))
+
+    with caplog.at_level(logging.WARNING, logger=client_mod.__name__):
+        assert _tasklist_has_image("OUTLOOK.EXE") is False
+
+    assert caplog.records == []
+
+
+def test_undecodable_output_is_logged(monkeypatch, caplog):
+    """stdout=None is what a decoding failure actually looks like — not a fact."""
+    _capture_run(monkeypatch, _FakeCompleted(stdout=None))
+
+    with caplog.at_level(logging.WARNING, logger=client_mod.__name__):
+        assert _tasklist_has_image("OUTLOOK.EXE") is False
+
+    assert any("no output" in r.getMessage() for r in caplog.records)
+
+
+def test_nonzero_exit_is_logged(monkeypatch, caplog):
+    _capture_run(monkeypatch, _FakeCompleted(stdout="", stderr="boom", returncode=1))
+
+    with caplog.at_level(logging.WARNING, logger=client_mod.__name__):
+        assert _tasklist_has_image("OUTLOOK.EXE") is False
+
+    assert any("exited 1" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.parametrize("exc", [
+    OSError("tasklist not found"),
+    subprocess.TimeoutExpired(cmd="tasklist", timeout=5),
+])
+def test_query_errors_are_logged(monkeypatch, caplog, exc):
+    _capture_run(monkeypatch, exc)
+
+    with caplog.at_level(logging.WARNING, logger=client_mod.__name__):
+        assert _tasklist_has_image("OUTLOOK.EXE") is False
+
+    assert any("Could not run tasklist" in r.getMessage() for r in caplog.records)
+
+
+def test_programming_errors_are_not_swallowed(monkeypatch):
+    """A genuine bug must surface, not be reported as 'Outlook not running'."""
+    _capture_run(monkeypatch, TypeError("bad call"))
+
+    with pytest.raises(TypeError):
+        _tasklist_has_image("OUTLOOK.EXE")
+
+
+# ------------------------------------------------------------- wiring ------
+
+
+def test_is_running_uses_tasklist_when_psutil_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "psutil", None)  # `import psutil` -> ImportError
+    asked: list[str] = []
+    monkeypatch.setattr(client_mod, "_tasklist_has_image",
+                        lambda name: asked.append(name) or True)
+
+    assert OutlookClient().is_running() is True
+    assert asked == ["OUTLOOK.EXE"]
+
+
+# ------------------------------------------- the real thing, end to end -----
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="tasklist/OEM decoding is Windows-only")
+def test_detects_running_process_under_pythonutf8(tmp_path):
+    """
+    Regression proof for #38, with no mocks in the path under test.
+
+    A process whose image name carries a non-ASCII character makes tasklist
+    emit a byte that is valid cp850 and invalid UTF-8 — the exact condition
+    that used to hand `text=True` a None stdout. The query runs in a child
+    interpreter with PYTHONUTF8=1, because that is the environment where the
+    old code reported a running process as not running.
+    """
+    ping = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "System32" / "PING.EXE"
+    if not ping.exists():
+        pytest.skip("PING.EXE not available on this machine")
+
+    probe = tmp_path / "prueba_ñ.exe"
+    shutil.copy2(ping, probe)
+
+    proc = subprocess.Popen(
+        [str(probe), "-n", "30", "127.0.0.1"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        creationflags=subprocess.CREATE_NO_WINDOW,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while not _tasklist_has_image(probe.name) and time.monotonic() < deadline:
+            time.sleep(0.2)
+
+        env = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
+        child = subprocess.run(
+            [sys.executable, "-c",
+             "import sys;"
+             "from email_archiver.outlook.client import _tasklist_has_image as q;"
+             "print(q(sys.argv[1]))",
+             probe.name],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=str(REPO_ROOT), env=env, timeout=60,
+        )
+        assert child.stdout.strip() == "True", (
+            f"child stdout={child.stdout!r} stderr={child.stderr!r}"
+        )
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="tasklist is Windows-only")
+def test_absent_process_reports_false():
+    assert _tasklist_has_image("definitely_not_running_38.exe") is False


### PR DESCRIPTION
## Summary

`OutlookClient.is_running()`'s `tasklist` fallback decoded the child's output with `text=True`, which uses the *parent's* ambient locale. Native Windows console tools write the OEM code page (cp850 here), so under `PYTHONUTF8=1` the decode fails and a running Outlook is silently reported as not running.

Reproduced empirically before fixing, and the real mechanism turned out to be slightly worse than the issue described: the `UnicodeDecodeError` is raised on `subprocess`' reader thread, so `subprocess.run` does **not** raise — it returns `stdout=None`, and the old `result.stdout.upper()` then raised `AttributeError` straight into the bare `except Exception: return False`. Same silent false negative, no log line, no exception.

Measured on this host (console-less parent + `CREATE_NO_WINDOW`, the app's real call shape): `OEMCP=850`, `ConsoleOutputCP=0`, raw `tasklist` bytes are cp850. `encoding="oem"` decodes them correctly; `text=True` under `PYTHONUTF8=1` yields `stdout=None`.

Changes:

- Pin `encoding="oem", errors="replace"` (guarded by `sys.platform == "win32"`, `utf-8` elsewhere) instead of inheriting the locale via `text=True`. `CREATE_NO_WINDOW` is preserved.
- A failed query is no longer indistinguishable from "Outlook is not running": distinct warnings for a spawn/timeout error, a non-zero exit, and unusable output.
- Narrow the bare `except Exception` to `(OSError, subprocess.SubprocessError)` so a genuine programming error surfaces instead of reading as "Outlook not running".
- Extract the query into `_tasklist_has_image()` so the regression test can drive the real call shape (no mocks) against a live process.

## Test plan

- [x] `tests/test_outlook_is_running.py` added — 11 tests: decoding kwargs pinned, `CREATE_NO_WINDOW` preserved, each failure mode logged distinctly, a successful no-match stays quiet, programming errors not swallowed, `is_running()` wiring when `psutil` is absent.
- [x] Regression test with **no mocks in the path under test**: copies `PING.EXE` to a temp file whose name carries a non-ASCII character (so `tasklist` emits a byte that is valid cp850 and invalid UTF-8), starts it, then queries it from a child interpreter with `PYTHONUTF8=1` and asserts it is detected.
- [x] Proven to fail pre-fix: reverting the helper to `text=True` fails exactly the two tests that lock the fix (`test_tasklist_pins_its_own_decoding`, `test_detects_running_process_under_pythonutf8`); restored and re-verified green.
- [x] Gate: `python -m compileall -q email_archiver tests` clean, `python -m pytest tests -q` → **15 passed**.
- [x] e2e: n/a — no suite, no web surface; deterministic tests are the coverage here.

Closes #38
