### PR TITLE
feat: date-first filenames for archived emails and attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,23 @@ Connects to the running Outlook instance, reads the currently selected email, qu
 
 ## File naming convention
 
-When an email is archived in a folder, files are named with a zero-padded 3-digit sequence number derived from the highest existing prefix in that folder, using ` - ` (space-dash-space) as the separator:
+When an email is archived in a folder, files are named `YYYY-MM-DD - NNN - <name>`, using ` - ` (space-dash-space) as the separator:
 
 ```
-023 - Project_Alpha_meeting_notes.msg
-023 - invoice.pdf
-023 - signed_contract.docx
+2026-03-14 - 023 - Project_Alpha_meeting_notes.msg
+2026-03-14 - 023 - invoice.pdf
+2026-03-14 - 023 - signed_contract.docx
 ```
 
-- The email gets `NNN - sanitized_subject.msg`
-- Each real attachment gets `NNN - original_filename.ext`
+- `YYYY-MM-DD` is the email's **sent** date (`SentOn`, falling back to `ReceivedTime`), normalized to local time — not the date it was archived. Attachments inherit the parent email's date, so a bundle stays contiguous.
+- `NNN` is a zero-padded 3-digit sequence number, derived from the highest existing prefix in that destination folder. It still groups a bundle (an email and its attachments share one `NNN`) and still increments per folder — its meaning and derivation are unchanged from before the date prefix was added.
+- The email gets `YYYY-MM-DD - NNN - sanitized_subject.msg`
+- Each real attachment gets `YYYY-MM-DD - NNN - original_filename.ext`
+- If the email's sent date cannot be resolved, archiving falls back to the legacy undated form (`NNN - sanitized_subject.msg`) and logs why, rather than inventing a placeholder date
+- Sequence allocation recognizes **both** the legacy `NNN - ` and the dated `YYYY-MM-DD - NNN - ` forms, so a folder holding a mix of old and newly-archived files still picks the correct next number and never collides
+- Existing archived files are never renamed — this only affects what gets written going forward
 - Embedded images (inline in HTML body) are skipped automatically; real attachments (e.g. PDFs) are saved even when the client sets a ContentId
-- The filename is dynamically shortened with a trailing `...` if the destination folder is deep enough that the full path would otherwise exceed Windows' 260-char `MAX_PATH` limit (e.g. `042 - Long_subject_starts_here....msg`)
+- The filename is dynamically shortened with a trailing `...` if the destination folder is deep enough that the full path would otherwise exceed Windows' 260-char `MAX_PATH` limit (e.g. `2026-03-14 - 042 - Long_subject_starts_here....msg`)
 
 ---
 

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -2,14 +2,18 @@
 Email archiver: saves .msg files and extracts attachments to disk.
 
 Naming convention (matches user spec):
-    Email:       NNN - sanitized_subject.msg
-    Attachments: NNN - filename.ext
+    Email:       YYYY-MM-DD - NNN - sanitized_subject.msg
+    Attachments: YYYY-MM-DD - NNN - filename.ext
 
-Where NNN is zero-padded to 3 digits (000–999).
+Where YYYY-MM-DD is the email's sent date in local time, and NNN is a
+zero-padded 3-digit sequence (000-999) shared by an email and its
+attachments. When the sent date cannot be resolved, the legacy undated form
+(``NNN - ...``) is used instead.
 
 Design decisions:
 - Sequence number is derived from the MAXIMUM existing numeric prefix in the
-  target folder, not a count, so it is safe even if files were deleted.
+  target folder, not a count, so it is safe even if files were deleted. The
+  scan recognises both the legacy and dated prefix forms.
 - Embedded images (ContentId set) are skipped; only real attachments are saved.
 - Subject sanitisation removes characters illegal on Windows file systems.
 - SaveAs uses olMSG format constant (3) to produce a proper .msg file.
@@ -31,8 +35,10 @@ logger = logging.getLogger(__name__)
 # Outlook SaveAs format constant for .msg
 _OL_MSG_FORMAT = 3
 
-# Regex to find the leading NNN_ prefix in filenames
-_RE_PREFIX = re.compile(r"^(\d+)")
+# Regexes to find the leading sequence number, in either filename form.
+# Dated is tried first since it is the more specific match.
+_RE_DATED_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2} - (\d{3}) - ")
+_RE_LEGACY_PREFIX = re.compile(r"^(\d{3}) - ")
 
 # Maximum path length (in chars) the fitted filename must stay within. This is
 # the SAME budget the scanner uses — sourced from config via
@@ -70,16 +76,19 @@ def _fit_filename_to_path(
     stem: str,
     suffix: str,
     *,
+    date_prefix: str | None = None,
     max_path: int = DEFAULT_MAX_PATH_LENGTH,
 ) -> str:
     """
-    Build ``"{seq} - {stem}{suffix}"`` such that the full path
-    ``os.path.join(folder_path, filename)`` stays within ``max_path`` chars.
+    Build ``"{date_prefix} - {seq} - {stem}{suffix}"`` (or, when
+    ``date_prefix`` is None, the legacy ``"{seq} - {stem}{suffix}"``) such
+    that the full path ``os.path.join(folder_path, filename)`` stays within
+    ``max_path`` chars.
 
     If the stem has to be cut, an ellipsis is appended so the resulting
     filename still hints at the original subject. ``suffix`` is preserved.
     """
-    prefix = f"{seq} - "
+    prefix = f"{date_prefix} - {seq} - " if date_prefix else f"{seq} - "
     sep_len = 1  # path separator inserted by os.path.join
     filename_budget = max_path - len(folder_path) - sep_len
     fixed = len(prefix) + len(suffix)
@@ -101,7 +110,8 @@ def _fit_filename_to_path(
 
 def get_next_sequence_number(folder_path: str) -> str:
     """
-    Scan the folder for files starting with NNN_ and return (max + 1).
+    Scan the folder for files starting with either the legacy ``NNN - `` or
+    the dated ``YYYY-MM-DD - NNN - `` prefix and return (max + 1).
     Returns '001' if the folder is empty or has no numbered files.
     """
     try:
@@ -112,7 +122,7 @@ def get_next_sequence_number(folder_path: str) -> str:
 
     numbers: list[int] = []
     for fname in files:
-        m = _RE_PREFIX.match(fname)
+        m = _RE_DATED_PREFIX.match(fname) or _RE_LEGACY_PREFIX.match(fname)
         if m:
             numbers.append(int(m.group(1)))
 
@@ -120,6 +130,38 @@ def get_next_sequence_number(folder_path: str) -> str:
     if next_num > 999:
         logger.warning("Sequence number exceeds 999 in %s", folder_path)
     return f"{next_num:03d}"
+
+
+def _get_sent_date_prefix(mail_item: Any) -> str | None:
+    """
+    Resolve the email's sent date as a ``YYYY-MM-DD`` string in local time.
+
+    Tries ``SentOn`` (the actual send time) first, falling back to
+    ``ReceivedTime``. Returns ``None`` — and logs why — when neither
+    resolves, signalling the caller to fall back to the legacy undated
+    filename form rather than invent a placeholder date.
+    """
+    last_exc: Exception | None = None
+    for attr in ("SentOn", "ReceivedTime"):
+        try:
+            value = getattr(mail_item, attr)
+        except Exception as exc:
+            last_exc = exc
+            continue
+        if value is None:
+            continue
+        try:
+            return f"{value.year:04d}-{value.month:02d}-{value.day:02d}"
+        except AttributeError as exc:
+            last_exc = exc
+            continue
+
+    logger.warning(
+        "Could not resolve a sent date for this email (%s); "
+        "falling back to the legacy undated filename form",
+        last_exc if last_exc is not None else "SentOn and ReceivedTime both empty",
+    )
+    return None
 
 
 # ------------------------------------------------------------- archiver -----
@@ -162,14 +204,17 @@ class EmailArchiver:
             dest.mkdir(parents=True, exist_ok=True)
 
         seq = get_next_sequence_number(folder_path)
+        date_prefix = _get_sent_date_prefix(mail_item)
         result = ArchiveResult(sequence_number=seq)
 
         # ---- save .msg ----
-        result.email_path = self._save_msg(mail_item, folder_path, seq, subject)
+        result.email_path = self._save_msg(
+            mail_item, folder_path, seq, subject, date_prefix
+        )
 
         # ---- save attachments ----
         result.attachment_paths = self._save_attachments(
-            mail_item, folder_path, seq
+            mail_item, folder_path, seq, date_prefix
         )
 
         logger.info(
@@ -186,10 +231,12 @@ class EmailArchiver:
         folder_path: str,
         seq: str,
         subject: str,
+        date_prefix: str | None,
     ) -> str:
         safe_subject = _sanitize_filename(subject)
         filename = _fit_filename_to_path(
-            folder_path, seq, safe_subject, ".msg", max_path=self._max_path
+            folder_path, seq, safe_subject, ".msg",
+            date_prefix=date_prefix, max_path=self._max_path,
         )
         file_path = os.path.join(folder_path, filename)
 
@@ -207,6 +254,7 @@ class EmailArchiver:
         mail_item: Any,
         folder_path: str,
         seq: str,
+        date_prefix: str | None,
     ) -> list[str]:
         saved: list[str] = []
         att_index = 1
@@ -254,7 +302,8 @@ class EmailArchiver:
                 suffix = Path(original_name).suffix.lower()
 
                 att_filename = _fit_filename_to_path(
-                    folder_path, seq, stem, suffix, max_path=self._max_path
+                    folder_path, seq, stem, suffix,
+                    date_prefix=date_prefix, max_path=self._max_path,
                 )
                 att_path = os.path.join(folder_path, att_filename)
                 # Avoid overwrite if multiple attachments share the same name.
@@ -264,7 +313,7 @@ class EmailArchiver:
                 while os.path.exists(att_path):
                     att_filename = _fit_filename_to_path(
                         folder_path, seq, f"{stem}_{counter}", suffix,
-                        max_path=self._max_path,
+                        date_prefix=date_prefix, max_path=self._max_path,
                     )
                     att_path = os.path.join(folder_path, att_filename)
                     counter += 1

--- a/tests/test_archiver_path_fit.py
+++ b/tests/test_archiver_path_fit.py
@@ -50,3 +50,35 @@ def test_pathological_folder_does_not_crash():
     name = _fit_filename_to_path(folder, "001", "anything", ".msg")
     assert name.startswith("001 - ")
     assert name.endswith(".msg")
+
+
+def test_date_prefix_is_prepended_when_short():
+    folder = r"C:\Users\me\OneDrive\Archive\Project Alpha"
+    name = _fit_filename_to_path(
+        folder, "042", "meeting_notes_q4", ".msg", date_prefix="2026-03-14"
+    )
+    assert name == "2026-03-14 - 042 - meeting_notes_q4.msg"
+    assert _full_len(folder, name) <= _WINDOWS_MAX_PATH
+
+
+def test_date_prefix_accounted_for_in_truncation_budget():
+    # Same folder/stem as the undated truncation case — the extra 13 chars of
+    # date prefix must come out of the stem budget, not blow the max path.
+    folder = r"C:\Users\me\OneDrive\Archive\\" + ("nested_subdir\\" * 12) + "Final"
+    long_stem = "Quarterly_planning_meeting_with_the_extended_leadership_team_recap_attachments"
+    name = _fit_filename_to_path(
+        folder, "007", long_stem, ".msg", date_prefix="2026-03-14"
+    )
+
+    assert _full_len(folder, name) <= _WINDOWS_MAX_PATH
+    assert name.startswith("2026-03-14 - 007 - ")
+    assert name.endswith(".msg")
+    assert _ELLIPSIS + ".msg" in name
+
+
+def test_no_date_prefix_falls_back_to_legacy_form():
+    folder = r"C:\Users\me\OneDrive\Archive\Project Alpha"
+    name = _fit_filename_to_path(
+        folder, "042", "meeting_notes_q4", ".msg", date_prefix=None
+    )
+    assert name == "042 - meeting_notes_q4.msg"

--- a/tests/test_archiver_sequencing.py
+++ b/tests/test_archiver_sequencing.py
@@ -1,0 +1,85 @@
+"""Tests for sequence-number derivation and sent-date resolution."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from email_archiver.archiver.archiver import (
+    _get_sent_date_prefix,
+    get_next_sequence_number,
+)
+
+
+class _FakeMailItem:
+    """Stand-in for the Outlook COM MailItem's date properties."""
+
+    def __init__(self, sent_on=None, received_time=None, raise_on_sent_on=False):
+        self._sent_on = sent_on
+        self._received_time = received_time
+        self._raise_on_sent_on = raise_on_sent_on
+
+    @property
+    def SentOn(self):
+        if self._raise_on_sent_on:
+            raise AttributeError("SentOn not available")
+        return self._sent_on
+
+    @property
+    def ReceivedTime(self):
+        return self._received_time
+
+
+# ------------------------------------------------------- get_next_sequence_number ---
+
+def test_empty_folder_starts_at_001(tmp_path):
+    assert get_next_sequence_number(str(tmp_path)) == "001"
+
+
+def test_legacy_only_folder_picks_max_plus_one(tmp_path):
+    (tmp_path / "001 - alpha.msg").write_text("x")
+    (tmp_path / "007 - beta.pdf").write_text("x")
+    assert get_next_sequence_number(str(tmp_path)) == "008"
+
+
+def test_dated_only_folder_picks_max_plus_one(tmp_path):
+    (tmp_path / "2026-01-01 - 003 - alpha.msg").write_text("x")
+    (tmp_path / "2026-03-14 - 012 - beta.pdf").write_text("x")
+    assert get_next_sequence_number(str(tmp_path)) == "013"
+
+
+def test_mixed_legacy_and_dated_folder_never_collides(tmp_path):
+    (tmp_path / "023 - old_email.msg").write_text("x")
+    (tmp_path / "2026-03-14 - 024 - new_email.msg").write_text("x")
+    assert get_next_sequence_number(str(tmp_path)) == "025"
+
+
+def test_dated_prefix_year_is_not_mistaken_for_sequence(tmp_path):
+    # A naive "leading digits" scan would read "2026" out of the date prefix
+    # as the sequence number. It must not.
+    (tmp_path / "2026-03-14 - 001 - only_file.msg").write_text("x")
+    assert get_next_sequence_number(str(tmp_path)) == "002"
+
+
+# ------------------------------------------------------------- _get_sent_date_prefix ---
+
+def test_sent_on_is_preferred():
+    item = _FakeMailItem(
+        sent_on=datetime(2026, 3, 14, 9, 30),
+        received_time=datetime(2026, 3, 15, 8, 0),
+    )
+    assert _get_sent_date_prefix(item) == "2026-03-14"
+
+
+def test_falls_back_to_received_time_when_sent_on_unavailable():
+    item = _FakeMailItem(
+        received_time=datetime(2026, 3, 15, 8, 0),
+        raise_on_sent_on=True,
+    )
+    assert _get_sent_date_prefix(item) == "2026-03-15"
+
+
+def test_returns_none_and_logs_when_neither_date_resolves(caplog):
+    item = _FakeMailItem(sent_on=None, received_time=None)
+    with caplog.at_level("WARNING"):
+        result = _get_sent_date_prefix(item)
+    assert result is None
+    assert any("sent date" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Archived filenames now lead with the email's sent date (`YYYY-MM-DD - NNN - <name>`) instead of the bare sequence prefix, so folders sort chronologically and stay compatible with a separate date-first document archive sharing the same OneDrive tree.
- Date is the email's sent date in local time (`SentOn`, falling back to `ReceivedTime`), computed once per email so the `.msg` and every real attachment share one date and one `NNN`.
- Sequence allocation now recognizes both the legacy `NNN - ` and new dated `YYYY-MM-DD - NNN - ` forms, so a folder holding a mix of old and new files still picks the correct next number and never collides — and no longer misreads a filename's leading year as a sequence number.
- When no sent date can be resolved, archiving falls back to the legacy undated form and logs why, rather than inventing a placeholder date.
- Path-length truncation budget already accounts for the (longer) prefix dynamically, since it's computed from the actual prefix string rather than a hardcoded length.
- Existing archived files are untouched — this only changes what gets written going forward.
- README's "File naming convention" section documents the new convention, `NNN` rationale, and mixed-folder behaviour.

## Validation
- `./.venv/Scripts/python.exe -m py_compile email_archiver/archiver/archiver.py` — clean.
- `./.venv/Scripts/python.exe -m pytest tests/ -v` — 26/26 passed, including 3 new path-fit tests (date prefix present/absent, truncation budget) and 8 new sequencing/date-resolution tests (mixed-folder collision avoidance, year-not-mistaken-for-sequence, SentOn/ReceivedTime fallback, unresolvable-date logging).
- Behavioural probe: exercised `EmailArchiver.archive()` end-to-end against a real temp folder with a fake Outlook MailItem — confirmed correct dated filenames for an email + 2 attachments, correct sequence continuity in a folder mixing a legacy-form file with new dated files, and correct fallback-to-legacy-form + warning log when no sent date resolves.
- `/e2e` routing: `WEB_SURFACE=no` (Tkinter/Outlook-COM desktop app, no browser surface) — n/a, no suite applicable; deterministic pytest is the coverage here.
- No CI configured in this repo (no `.github/workflows`).
- Independent fresh-agent review: re-fetched the issue's acceptance criteria, re-read the diff, independently re-ran compile + pytest (26/26 passed), judged the diff against every acceptance bullet — verdict: pass.

## Test plan
- [x] Archiving an email writes `YYYY-MM-DD - NNN - <slug>.<ext>` for the `.msg` and every real attachment, all sharing one date and one `NNN`.
- [x] The date is the email's sent date in local time, not the archive time.
- [x] Sequence allocation reads both the legacy `NNN - ` and the new `YYYY-MM-DD - NNN - ` forms; archiving into a folder holding a mix picks the correct next number and never collides.
- [x] An email with no resolvable sent date falls back to the legacy form and logs why.
- [x] Path shortening accounts for the longer prefix; archiving into a folder near the 260-char limit still succeeds and still produces a readable name.
- [x] Embedded inline images are still skipped; real attachments are still saved (unchanged logic, verified by probe).
- [x] Existing archived files are untouched (write-only change; no rename path exists).
- [x] README's file-naming section documents the new convention, the `NNN` rationale, and the mixed-folder behaviour.

Closes #40