### PR TITLE
Make the date prefix opt-in and add an Explorer-folder archive button

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,39 @@ Two commands, each launchable from a Stream Deck button or the command line:
 Walks the entire OneDrive archive from a configured root folder, opens every `.msg` file it finds, extracts metadata (subject, sender, recipients, date, body preview), and stores it in a local SQLite database with a full-text search index. Subsequent scans are incremental — only new or modified files are processed.
 
 ### 2. Archive Email
-Connects to the running Outlook instance, reads the currently selected email, queries the database to find the most relevant project folders, and presents ranked suggestions. You click a folder (or browse manually), confirm, and the email is saved as a `.msg` file plus all attachments — all consistently numbered — in under two seconds. The window closes immediately after saving (no confirmation popup); the log file records what was saved.
+Connects to the running Outlook instance, reads the currently selected email, queries the database to find the most relevant project folders, and presents ranked suggestions. You click a folder, confirm, and the email is saved as a `.msg` file plus all attachments — all consistently numbered — in under two seconds. The window closes immediately after saving (no confirmation popup); the log file records what was saved.
+
+When none of the suggestions is right there are two escapes, both in the dialog's bottom bar:
+
+| Button | What it does |
+|---|---|
+| **Browse folder…** | Opens the native folder picker, starting at the first configured archive root |
+| **Explorer folder** | Archives straight into the folder shown in the **foremost open File Explorer window** — the one you looked at last. No picker, no typing. |
+
+`Explorer folder` is for the case where the right destination is already open on screen. It only considers real filesystem folders (virtual shell locations like *This PC* or *Quick Access* are skipped), it is **not** limited to the configured archive roots, and if no Explorer window is showing a real folder it says so rather than guessing.
 
 ---
 
 ## File naming convention
 
-When an email is archived in a folder, files are named `YYYY-MM-DD - NNN - <name>`, using ` - ` (space-dash-space) as the separator:
+When an email is archived in a folder, files are named `NNN - <name>`, using ` - ` (space-dash-space) as the separator:
+
+```
+023 - Project_Alpha_meeting_notes.msg
+023 - invoice.pdf
+023 - signed_contract.docx
+```
+
+- `NNN` is a zero-padded 3-digit sequence number, derived from the highest existing prefix in that destination folder. It groups a bundle — an email and its attachments always share one `NNN` — and increments per folder.
+- The email gets `NNN - sanitized_subject.msg`
+- Each real attachment gets `NNN - original_filename.ext`
+- Existing archived files are never renamed — this only affects what gets written going forward
+- Embedded images (inline in HTML body) are skipped automatically; real attachments (e.g. PDFs) are saved even when the client sets a ContentId
+- The filename is dynamically shortened with a trailing `...` if the destination folder is deep enough that the full path would otherwise exceed Windows' 260-char `MAX_PATH` limit (e.g. `042 - Long_subject_starts_here....msg`)
+
+### Optional date prefix
+
+The email's sent date can be prefixed to every name in the bundle, for folders shared with a document archive that files everything as `YYYY-MM-DD - <slug>`:
 
 ```
 2026-03-14 - 023 - Project_Alpha_meeting_notes.msg
@@ -44,15 +70,21 @@ When an email is archived in a folder, files are named `YYYY-MM-DD - NNN - <name
 2026-03-14 - 023 - signed_contract.docx
 ```
 
+It is **off by default** and can be switched on two ways:
+
+- **Per archive** — the **Date prefix (YYYY-MM-DD)** checkbox in the archive dialog's bottom bar. Tick it before clicking `Archive`, `Browse folder…` or `Explorer folder`; it applies to that archive only and nothing is written to the config.
+- **Permanently** — `naming.date_prefix: true` in `config/config.yaml`. That sets the checkbox's starting position every time the dialog opens, so the per-archive checkbox can still override it in either direction.
+
+```yaml
+naming:
+  date_prefix: false   # default; true → 2026-03-14 - 023 - subject.msg
+```
+
 - `YYYY-MM-DD` is the email's **sent** date (`SentOn`, falling back to `ReceivedTime`), normalized to local time — not the date it was archived. Attachments inherit the parent email's date, so a bundle stays contiguous.
-- `NNN` is a zero-padded 3-digit sequence number, derived from the highest existing prefix in that destination folder. It still groups a bundle (an email and its attachments share one `NNN`) and still increments per folder — its meaning and derivation are unchanged from before the date prefix was added.
-- The email gets `YYYY-MM-DD - NNN - sanitized_subject.msg`
-- Each real attachment gets `YYYY-MM-DD - NNN - original_filename.ext`
-- If the email's sent date cannot be resolved, archiving falls back to the legacy undated form (`NNN - sanitized_subject.msg`) and logs why, rather than inventing a placeholder date
-- Sequence allocation recognizes **both** the legacy `NNN - ` and the dated `YYYY-MM-DD - NNN - ` forms, so a folder holding a mix of old and newly-archived files still picks the correct next number and never collides
-- Existing archived files are never renamed — this only affects what gets written going forward
-- Embedded images (inline in HTML body) are skipped automatically; real attachments (e.g. PDFs) are saved even when the client sets a ContentId
-- The filename is dynamically shortened with a trailing `...` if the destination folder is deep enough that the full path would otherwise exceed Windows' 260-char `MAX_PATH` limit (e.g. `2026-03-14 - 042 - Long_subject_starts_here....msg`)
+- `NNN` keeps exactly the same meaning and derivation with the prefix on
+- If the email's sent date cannot be resolved, that archive falls back to the undated form and logs why, rather than inventing a placeholder date
+- Sequence allocation recognizes **both** the `NNN - ` and the `YYYY-MM-DD - NNN - ` forms no matter which one is being written, so a folder holding a mix of both still picks the correct next number and never collides — the toggle is safe to flip at any time
+- Path shortening accounts for the 13 extra characters only when the prefix is actually applied
 
 ---
 
@@ -74,6 +106,7 @@ archiver/
 ├── email_archiver/              ← Main package
 │   ├── config.py                ← YAML loader, path resolution, logging setup
 │   ├── text.py                  ← Shared subject normalisation (Re:/Fwd: stripping)
+│   ├── explorer.py              ← Foremost open Explorer window → folder path
 │   │
 │   ├── database/
 │   │   ├── models.py            ← SQLite schema, FTS5 setup, connection factory
@@ -152,7 +185,7 @@ archive:
     - "C:/Users/YourName/OneDrive/Archive/"
 ```
 
-All other defaults are sensible out of the box.
+All other defaults are sensible out of the box. The one knob worth knowing about is `naming.date_prefix` (default `false`) — see [File naming convention](#file-naming-convention).
 
 ### First scan
 
@@ -285,7 +318,8 @@ WAL journal mode is enabled so the archive command can read the DB while a scan 
 | **Incremental scan** | No — re-read all files every time | Yes — `mtime` check, skips unchanged files |
 | **Architecture** | 3 flat scripts + shared utils | Package with 6 separated modules |
 | **UI** | Blocking `window.mainloop()` per dialog | Background thread, non-blocking |
-| **Attachments** | (varies) | `NNN - filename.ext` (email: `NNN - subject.msg`) |
+| **Attachments** | (varies) | `NNN - filename.ext` (email: `NNN - subject.msg`), optional `YYYY-MM-DD - ` prefix |
+| **Save to open Explorer folder** | Separate script (`email-automation-save.py`) | `Explorer folder` button in the archive dialog |
 | **Exchange resolution** | Partial | Full `GetExchangeUser()` SMTP fallback |
 | **Logging** | `print()` statements | Structured `logging` to file + console |
 | **Config** | Hardcoded `.txt` params files | `config/config.yaml` |

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -11,6 +11,16 @@ archive:
     - "C:/Users/YourName/OneDrive/Documentos/"
     - "C:/Users/YourName/OneDrive/Archive/"
 
+naming:
+  # Prepend the email's sent date to archived filenames.
+  #   false (default) → 023 - subject.msg
+  #   true            → 2026-03-14 - 023 - subject.msg
+  # The NNN sequence is always present and always shared by an email and its
+  # attachments. Sequence allocation reads both forms whichever way this is
+  # set, so it is safe to flip at any time — a folder holding a mix of dated
+  # and undated files still gets the correct next number.
+  date_prefix: false
+
 database:
   # Path relative to the project root or absolute
   path: "data/emails.db"

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -34,6 +34,9 @@ flowchart TB
   LAUNCHER --> ARCHIVEDIALOG
   LAUNCHER --> SCANWINDOW
   ARCHIVEDIALOG --> DIALOGS
+  ARCHIVEDIALOG -->|Explorer folder button| EXPLORER
+  EXPLORER["explorer.py: get_current_explorer_folder\nShell.Application windows + z-order pick"]
+  EXPLORER -->|Shell.Application / EnumWindows| SHELLCOM["Windows shell\n(open File Explorer windows)"]
 
   subgraph scan["Scan Archive data flow"]
     SCANNER["scanner/scanner.py\nFolderScanner — incremental os.walk,\nmtime compare, batch commits"]
@@ -55,7 +58,7 @@ flowchart TB
   subgraph archive["Archive Email data flow"]
     OUTLOOK["outlook/client.py: OutlookClient\nCOM isolation, SMTP resolution\n(GetExchangeUser fallback)"]
     SUGGESTER["engine/suggester.py: SuggestionEngine\n3-stage blend: 0.45 FTS + 0.30 subject-thread\n+ 0.25 folder-name (rapidfuzz)"]
-    ARCHIVER["archiver/archiver.py: EmailArchiver\nNNN - filename sequencing, path-length fit,\nSaveAs .msg + SaveAsFile attachments"]
+    ARCHIVER["archiver/archiver.py: EmailArchiver\nNNN - sequencing, optional YYYY-MM-DD prefix,\npath-length fit, SaveAs .msg + SaveAsFile attachments"]
   end
   ARCHIVEDIALOG --> OUTLOOK
   OUTLOOK -->|win32com| OUTLOOKCOM["Outlook COM\n(running Outlook.exe process)"]
@@ -64,6 +67,6 @@ flowchart TB
   ARCHIVEDIALOG --> SUGGESTER
   SUGGESTER --> REPO
   SUGGESTER -->|rapidfuzz| RAPIDFUZZ["rapidfuzz (pip package)"]
-  ARCHIVEDIALOG -->|user confirms folder| ARCHIVER
+  ARCHIVEDIALOG -->|user confirms folder + date-prefix checkbox| ARCHIVER
   ARCHIVER -->|SaveAs / SaveAsFile via| OUTLOOKCOM
   ARCHIVER -->|writes .msg + attachments| ONEDRIVE

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -2,18 +2,25 @@
 Email archiver: saves .msg files and extracts attachments to disk.
 
 Naming convention (matches user spec):
+    Email:       NNN - sanitized_subject.msg
+    Attachments: NNN - filename.ext
+
+NNN is a zero-padded 3-digit sequence (000-999) shared by an email and its
+attachments. With ``naming.date_prefix: true`` in the config, the email's sent
+date in local time is prefixed as well:
+
     Email:       YYYY-MM-DD - NNN - sanitized_subject.msg
     Attachments: YYYY-MM-DD - NNN - filename.ext
 
-Where YYYY-MM-DD is the email's sent date in local time, and NNN is a
-zero-padded 3-digit sequence (000-999) shared by an email and its
-attachments. When the sent date cannot be resolved, the legacy undated form
-(``NNN - ...``) is used instead.
+The toggle is off by default. When it is on but the sent date cannot be
+resolved, the undated form is used for that email instead.
 
 Design decisions:
 - Sequence number is derived from the MAXIMUM existing numeric prefix in the
   target folder, not a count, so it is safe even if files were deleted. The
-  scan recognises both the legacy and dated prefix forms.
+  scan recognises both prefix forms regardless of the toggle, so a folder
+  holding a mix of dated and undated files always allocates the next number
+  correctly and the toggle stays safe to flip at any time.
 - Embedded images (ContentId set) are skipped; only real attachments are saved.
 - Subject sanitisation removes characters illegal on Windows file systems.
 - SaveAs uses olMSG format constant (3) to produce a proper .msg file.
@@ -28,7 +35,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from email_archiver.config import DEFAULT_MAX_PATH_LENGTH, get_max_path_length
+from email_archiver.config import (
+    DEFAULT_DATE_PREFIX_ENABLED,
+    DEFAULT_MAX_PATH_LENGTH,
+    get_date_prefix_enabled,
+    get_max_path_length,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +50,7 @@ _OL_MSG_FORMAT = 3
 # Regexes to find the leading sequence number, in either filename form.
 # Dated is tried first since it is the more specific match.
 _RE_DATED_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2} - (\d{3}) - ")
-_RE_LEGACY_PREFIX = re.compile(r"^(\d{3}) - ")
+_RE_UNDATED_PREFIX = re.compile(r"^(\d{3}) - ")
 
 # Maximum path length (in chars) the fitted filename must stay within. This is
 # the SAME budget the scanner uses — sourced from config via
@@ -80,10 +92,11 @@ def _fit_filename_to_path(
     max_path: int = DEFAULT_MAX_PATH_LENGTH,
 ) -> str:
     """
-    Build ``"{date_prefix} - {seq} - {stem}{suffix}"`` (or, when
-    ``date_prefix`` is None, the legacy ``"{seq} - {stem}{suffix}"``) such
-    that the full path ``os.path.join(folder_path, filename)`` stays within
-    ``max_path`` chars.
+    Build ``"{seq} - {stem}{suffix}"`` — or, when ``date_prefix`` is given,
+    ``"{date_prefix} - {seq} - {stem}{suffix}"`` — such that the full path
+    ``os.path.join(folder_path, filename)`` stays within ``max_path`` chars.
+    The date prefix costs 13 chars and comes out of the stem's budget, never
+    out of the path limit.
 
     If the stem has to be cut, an ellipsis is appended so the resulting
     filename still hints at the original subject. ``suffix`` is preserved.
@@ -110,8 +123,10 @@ def _fit_filename_to_path(
 
 def get_next_sequence_number(folder_path: str) -> str:
     """
-    Scan the folder for files starting with either the legacy ``NNN - `` or
+    Scan the folder for files starting with either the undated ``NNN - `` or
     the dated ``YYYY-MM-DD - NNN - `` prefix and return (max + 1).
+    Both forms are always recognised, independently of which form this run
+    writes, so a folder holding a mix never gets a colliding number.
     Returns '001' if the folder is empty or has no numbered files.
     """
     try:
@@ -122,7 +137,7 @@ def get_next_sequence_number(folder_path: str) -> str:
 
     numbers: list[int] = []
     for fname in files:
-        m = _RE_DATED_PREFIX.match(fname) or _RE_LEGACY_PREFIX.match(fname)
+        m = _RE_DATED_PREFIX.match(fname) or _RE_UNDATED_PREFIX.match(fname)
         if m:
             numbers.append(int(m.group(1)))
 
@@ -136,10 +151,11 @@ def _get_sent_date_prefix(mail_item: Any) -> str | None:
     """
     Resolve the email's sent date as a ``YYYY-MM-DD`` string in local time.
 
-    Tries ``SentOn`` (the actual send time) first, falling back to
-    ``ReceivedTime``. Returns ``None`` — and logs why — when neither
-    resolves, signalling the caller to fall back to the legacy undated
-    filename form rather than invent a placeholder date.
+    Only called when ``naming.date_prefix`` is on. Tries ``SentOn`` (the
+    actual send time) first, falling back to ``ReceivedTime``. Returns
+    ``None`` — and logs why — when neither resolves, signalling the caller to
+    fall back to the undated filename form rather than invent a placeholder
+    date.
     """
     last_exc: Exception | None = None
     for attr in ("SentOn", "ReceivedTime"):
@@ -158,7 +174,7 @@ def _get_sent_date_prefix(mail_item: Any) -> str | None:
 
     logger.warning(
         "Could not resolve a sent date for this email (%s); "
-        "falling back to the legacy undated filename form",
+        "falling back to the undated filename form",
         last_exc if last_exc is not None else "SentOn and ReceivedTime both empty",
     )
     return None
@@ -169,17 +185,35 @@ def _get_sent_date_prefix(mail_item: Any) -> str | None:
 class EmailArchiver:
     """Saves an Outlook MailItem (COM object) to a target folder on disk."""
 
-    def __init__(self, cfg: dict[str, Any] | None = None) -> None:
-        """Build an archiver bound to a path-length budget.
+    def __init__(
+        self,
+        cfg: dict[str, Any] | None = None,
+        *,
+        date_prefix: bool | None = None,
+    ) -> None:
+        """Build an archiver bound to a path-length budget and a naming form.
 
         ``cfg`` is the loaded config dict; the path budget is read from it via
         the shared ``get_max_path_length`` accessor so the archiver and scanner
-        honour the same ``path.max_length`` knob. When ``cfg`` is omitted the
-        ``DEFAULT_MAX_PATH_LENGTH`` fallback is used.
+        honour the same ``path.max_length`` knob, and the sent-date prefix
+        toggle via ``get_date_prefix_enabled`` (``naming.date_prefix``). When
+        ``cfg`` is omitted the ``DEFAULT_*`` fallbacks are used.
+
+        ``date_prefix`` overrides the configured toggle for this archiver only
+        — the archive dialog passes its checkbox state through here, so the
+        config value is the checkbox's *starting* position rather than the last
+        word. ``None`` (the default) means "use the config".
         """
         self._max_path: int = (
             get_max_path_length(cfg) if cfg is not None else DEFAULT_MAX_PATH_LENGTH
         )
+        self._date_prefix_enabled: bool
+        if date_prefix is not None:
+            self._date_prefix_enabled = date_prefix
+        elif cfg is not None:
+            self._date_prefix_enabled = get_date_prefix_enabled(cfg)
+        else:
+            self._date_prefix_enabled = DEFAULT_DATE_PREFIX_ENABLED
 
     def archive(
         self,
@@ -204,7 +238,9 @@ class EmailArchiver:
             dest.mkdir(parents=True, exist_ok=True)
 
         seq = get_next_sequence_number(folder_path)
-        date_prefix = _get_sent_date_prefix(mail_item)
+        date_prefix = (
+            _get_sent_date_prefix(mail_item) if self._date_prefix_enabled else None
+        )
         result = ArchiveResult(sequence_number=seq)
 
         # ---- save .msg ----

--- a/email_archiver/config.py
+++ b/email_archiver/config.py
@@ -24,6 +24,12 @@ CONFIG_FILE = PROJECT_ROOT / "config" / "config.yaml"
 # key so older config.yaml files keep working.
 DEFAULT_MAX_PATH_LENGTH = 255
 
+# Archived filenames carry the sequence prefix only (``NNN - name.ext``) unless
+# the sent-date prefix is explicitly switched on. Off by default: the shorter
+# form leaves more MAX_PATH headroom in deep folders, and the date is already
+# inside the .msg. See ``get_date_prefix_enabled``.
+DEFAULT_DATE_PREFIX_ENABLED = False
+
 _config: dict[str, Any] | None = None
 
 
@@ -77,6 +83,23 @@ def get_max_path_length(cfg: dict[str, Any]) -> int:
     if value is None:
         return DEFAULT_MAX_PATH_LENGTH
     return int(value)
+
+
+def get_date_prefix_enabled(cfg: dict[str, Any]) -> bool:
+    """Return whether archived filenames get the email's sent date prefixed.
+
+    Reads ``naming.date_prefix``, falling back to
+    ``DEFAULT_DATE_PREFIX_ENABLED`` (``False``) when the section or key is
+    absent, so a ``config.yaml`` written before the toggle existed keeps the
+    default sequence-only naming. Like ``get_max_path_length``, this is the one
+    place the key is read — the archiver goes through it rather than reaching
+    into the config dict itself.
+    """
+    naming_cfg = cfg.get("naming") or {}
+    value = naming_cfg.get("date_prefix")
+    if value is None:
+        return DEFAULT_DATE_PREFIX_ENABLED
+    return bool(value)
 
 
 def _resolve_paths(cfg: dict[str, Any]) -> None:

--- a/email_archiver/explorer.py
+++ b/email_archiver/explorer.py
@@ -12,7 +12,10 @@ Two layers, deliberately split:
   tested directly.
 - ``get_current_explorer_folder`` does the Windows-specific part: enumerate the
   shell's open windows, keep the ones showing a real filesystem folder, read the
-  top-level window z-order, and hand both to the pure picker.
+  top-level window z-order, and hand both to the pure picker. It distinguishes
+  "the shell says nothing is open" (``None``) from "the shell could not be
+  asked" (``ExplorerUnavailableError``) — the second is not evidence of the
+  first.
 
 "Foremost" means highest in the z-order — the Explorer window the user looked
 at last, not an arbitrary one from the shell's collection. The archive dialog
@@ -29,6 +32,16 @@ logger = logging.getLogger(__name__)
 # Shell windows whose hosting executable is not Explorer (legacy Internet
 # Explorer instances still surface in the same collection) are not destinations.
 _EXPLORER_EXE = "explorer.exe"
+
+
+class ExplorerUnavailableError(RuntimeError):
+    """The Windows shell could not be queried at all.
+
+    Distinct from "no Explorer window is open", which is a real answer to the
+    question. Failing to establish the fact is its own state and gets its own
+    message — collapsing the two would tell the user to open a folder in
+    Explorer when the actual problem is that COM is unreachable.
+    """
 
 
 def pick_foremost_folder(
@@ -104,9 +117,11 @@ def get_current_explorer_folder() -> str | None:
     """
     Return the filesystem path shown in the foremost open File Explorer window.
 
-    Returns ``None`` — and logs why — when no Explorer window is showing a real
-    folder, or when the shell cannot be reached at all. The caller is expected
-    to tell the user rather than pick a destination of its own.
+    Returns ``None`` — and logs it — when the shell answered but no Explorer
+    window is showing a real folder. Raises ``ExplorerUnavailableError`` when
+    the shell could not be asked at all; the caller must not read that as
+    "nothing is open". Either way the caller tells the user rather than picking
+    a destination of its own.
     """
     try:
         import pythoncom  # noqa: PLC0415 - Windows-only, imported at use site
@@ -117,13 +132,13 @@ def get_current_explorer_folder() -> str | None:
         pythoncom.CoInitialize()
     except Exception as exc:
         logger.warning("Cannot initialise COM to read Explorer windows: %s", exc)
-        return None
+        raise ExplorerUnavailableError(str(exc)) from exc
 
     try:
         folders = _enumerate_explorer_folders()
     except Exception as exc:
         logger.warning("Cannot enumerate Explorer windows: %s", exc)
-        return None
+        raise ExplorerUnavailableError(str(exc)) from exc
 
     if not folders:
         logger.info("No open File Explorer window is showing a real folder")

--- a/email_archiver/explorer.py
+++ b/email_archiver/explorer.py
@@ -1,0 +1,141 @@
+"""
+Resolve the folder shown in the foremost open Windows File Explorer window.
+
+Used by the archive dialog's "Explorer folder" button: when none of the ranked
+suggestions is right but the correct destination is already open on screen,
+archiving into it should not require walking a folder picker.
+
+Two layers, deliberately split:
+
+- ``pick_foremost_folder`` is pure — given the eligible windows and the current
+  z-order it decides which one wins. It has no COM dependency and is unit
+  tested directly.
+- ``get_current_explorer_folder`` does the Windows-specific part: enumerate the
+  shell's open windows, keep the ones showing a real filesystem folder, read the
+  top-level window z-order, and hand both to the pure picker.
+
+"Foremost" means highest in the z-order — the Explorer window the user looked
+at last, not an arbitrary one from the shell's collection. The archive dialog
+itself is a topmost window but is not an Explorer window, so it never wins.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+# Shell windows whose hosting executable is not Explorer (legacy Internet
+# Explorer instances still surface in the same collection) are not destinations.
+_EXPLORER_EXE = "explorer.exe"
+
+
+def pick_foremost_folder(
+    folders_by_hwnd: dict[int, str],
+    z_order: Sequence[int],
+) -> str | None:
+    """
+    Choose the winning folder from the eligible Explorer windows.
+
+    Args:
+        folders_by_hwnd: window handle → filesystem folder path, in the order
+            the shell enumerated them (roughly oldest window first).
+        z_order: top-level window handles, topmost first, as reported by the
+            window manager. May contain handles that are not Explorer windows.
+
+    Returns:
+        The folder of the highest-z-order eligible window; when none of the
+        eligible windows appears in ``z_order`` at all, the last-enumerated
+        one (the most recently opened) as a fallback; ``None`` when there are
+        no eligible windows.
+    """
+    if not folders_by_hwnd:
+        return None
+
+    for hwnd in z_order:
+        folder = folders_by_hwnd.get(hwnd)
+        if folder is not None:
+            return folder
+
+    # No eligible window was found in the z-order (minimised on some Windows
+    # builds, or the enumeration raced a window closing). Falling back to the
+    # newest window is closer to "the one the user just opened" than the oldest.
+    return list(folders_by_hwnd.values())[-1]
+
+
+def _enumerate_explorer_folders() -> dict[int, str]:
+    """Map window handle → folder path for every open File Explorer window
+    that is showing a real filesystem folder.
+
+    Virtual shell locations (This PC, Control Panel, Quick Access, Recycle Bin)
+    have no usable path and are skipped, as are non-Explorer shell windows.
+    """
+    import win32com.client  # noqa: PLC0415 - Windows-only, imported at use site
+
+    folders: dict[int, str] = {}
+    for window in win32com.client.Dispatch("Shell.Application").Windows():
+        try:
+            if not str(window.FullName or "").lower().endswith(_EXPLORER_EXE):
+                continue
+            hwnd = int(window.HWND)
+            path = str(window.Document.Folder.Self.Path or "")
+        except Exception as exc:  # a window can close mid-enumeration
+            logger.debug("Skipping a shell window: %s", exc)
+            continue
+
+        if path and os.path.isdir(path):
+            folders[hwnd] = path
+
+    return folders
+
+
+def _top_level_z_order() -> list[int]:
+    """Top-level window handles, topmost first."""
+    import win32gui  # noqa: PLC0415 - Windows-only, imported at use site
+
+    handles: list[int] = []
+    # EnumWindows walks top-level windows in z-order, topmost first.
+    win32gui.EnumWindows(lambda hwnd, acc: acc.append(hwnd), handles)
+    return handles
+
+
+def get_current_explorer_folder() -> str | None:
+    """
+    Return the filesystem path shown in the foremost open File Explorer window.
+
+    Returns ``None`` — and logs why — when no Explorer window is showing a real
+    folder, or when the shell cannot be reached at all. The caller is expected
+    to tell the user rather than pick a destination of its own.
+    """
+    try:
+        import pythoncom  # noqa: PLC0415 - Windows-only, imported at use site
+
+        # The Tk callback runs on the main thread, which may not have been
+        # COM-initialised yet. CoInitialize is reference-counted and safe to
+        # call again on a thread that already has an apartment.
+        pythoncom.CoInitialize()
+    except Exception as exc:
+        logger.warning("Cannot initialise COM to read Explorer windows: %s", exc)
+        return None
+
+    try:
+        folders = _enumerate_explorer_folders()
+    except Exception as exc:
+        logger.warning("Cannot enumerate Explorer windows: %s", exc)
+        return None
+
+    if not folders:
+        logger.info("No open File Explorer window is showing a real folder")
+        return None
+
+    try:
+        z_order = _top_level_z_order()
+    except Exception as exc:
+        # Without a z-order the newest-window fallback still gives an answer.
+        logger.warning("Cannot read the window z-order: %s", exc)
+        z_order = []
+
+    chosen = pick_foremost_folder(folders, z_order)
+    logger.info("Foremost Explorer folder: %s", chosen)
+    return chosen

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -21,8 +21,9 @@ from tkinter import messagebox, ttk
 from typing import Any
 
 from email_archiver.archiver.archiver import EmailArchiver
-from email_archiver.config import get_archive_roots
+from email_archiver.config import get_archive_roots, get_date_prefix_enabled
 from email_archiver.engine.suggester import RankedSuggestion, SuggestionEngine
+from email_archiver.explorer import get_current_explorer_folder
 from email_archiver.outlook.client import EmailData, OutlookClient, get_selected_mail_item
 from email_archiver.ui.dialogs import browse_folder
 
@@ -72,6 +73,11 @@ class ArchiveDialog:
         sh = self._root.winfo_screenheight()
         self._root.geometry(f"{w}x{h}+{(sw - w) // 2}+{(sh - h) // 2}")
         self._root.attributes("-topmost", True)
+
+        # Must exist before _build_ui: the checkbox binds to it. Seeded from
+        # naming.date_prefix so the config sets the default position and the
+        # user can still flip it per archive.
+        self._date_prefix_var = tk.BooleanVar(value=get_date_prefix_enabled(cfg))
 
         self._build_ui()
         self._root.bind("<Escape>", lambda e: self._root.destroy())
@@ -139,12 +145,31 @@ class ArchiveDialog:
             font=(ff, fn),
         ).pack(side="left")
 
+        # Per-archive naming opt-in. Starts at the configured
+        # naming.date_prefix (off unless the config says otherwise); ticking it
+        # applies the date prefix to this archive only, without editing config.
+        tk.Checkbutton(
+            bottom, text="Date prefix (YYYY-MM-DD)",
+            variable=self._date_prefix_var,
+            bg=_BG, activebackground=_BG, fg="#333",
+            font=(ff, fn), padx=8,
+        ).pack(side="left", padx=(12, 0))
+
+        # Cancel is packed first so it sits furthest right; the Explorer-folder
+        # escape hatch is packed after it and therefore lands to its left.
         tk.Button(
             bottom, text="✗  Cancel",
             command=self._root.destroy,
             relief="flat", bg="#e0e0e0", padx=8, pady=4,
             font=(ff, fn),
         ).pack(side="right")
+
+        tk.Button(
+            bottom, text="🗔  Explorer folder",
+            command=self._on_explorer_folder,
+            relief="flat", bg="#e0e0e0", padx=8, pady=4,
+            font=(ff, fn),
+        ).pack(side="right", padx=(0, 8))
 
     # ------------------------------------------------ background loading ---
 
@@ -298,6 +323,25 @@ class ArchiveDialog:
         if chosen:
             self._do_archive(chosen)
 
+    def _on_explorer_folder(self) -> None:
+        """Archive into the folder shown in the foremost open Explorer window.
+
+        The destination is deliberately not restricted to the configured
+        archive roots — the point of this button is to reach a folder the
+        ranked suggestions could not.
+        """
+        folder = get_current_explorer_folder()
+        if not folder:
+            messagebox.showinfo(
+                "No Explorer folder",
+                "No open File Explorer window is showing a real folder.\n\n"
+                "Open the destination folder in Explorer and try again, "
+                "or use 'Browse folder…'.",
+                parent=self._root,
+            )
+            return
+        self._do_archive(folder)
+
     def _do_archive(self, folder_path: str) -> None:
         if not self._email:
             messagebox.showerror("Error", "Email data not available.")
@@ -322,7 +366,9 @@ class ArchiveDialog:
                 messagebox.showerror("Outlook error", f"Cannot access Outlook:\n{exc}")
                 return
 
-            archiver = EmailArchiver(self._cfg)
+            archiver = EmailArchiver(
+                self._cfg, date_prefix=self._date_prefix_var.get()
+            )
             result = archiver.archive(
                 mail_item=mail_item,
                 folder_path=folder_path,

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -23,7 +23,10 @@ from typing import Any
 from email_archiver.archiver.archiver import EmailArchiver
 from email_archiver.config import get_archive_roots, get_date_prefix_enabled
 from email_archiver.engine.suggester import RankedSuggestion, SuggestionEngine
-from email_archiver.explorer import get_current_explorer_folder
+from email_archiver.explorer import (
+    ExplorerUnavailableError,
+    get_current_explorer_folder,
+)
 from email_archiver.outlook.client import EmailData, OutlookClient, get_selected_mail_item
 from email_archiver.ui.dialogs import browse_folder
 
@@ -330,7 +333,20 @@ class ArchiveDialog:
         archive roots — the point of this button is to reach a folder the
         ranked suggestions could not.
         """
-        folder = get_current_explorer_folder()
+        try:
+            folder = get_current_explorer_folder()
+        except ExplorerUnavailableError as exc:
+            # Distinct from "nothing is open" — Windows could not be asked, so
+            # saying "open a folder in Explorer" would send the user chasing
+            # the wrong thing.
+            messagebox.showerror(
+                "Cannot read Explorer windows",
+                f"Windows could not tell us which folders are open:\n{exc}\n\n"
+                "Use 'Browse folder…' instead.",
+                parent=self._root,
+            )
+            return
+
         if not folder:
             messagebox.showinfo(
                 "No Explorer folder",

--- a/tests/test_archiver_date_prefix_toggle.py
+++ b/tests/test_archiver_date_prefix_toggle.py
@@ -1,24 +1,46 @@
 """Tests for the naming.date_prefix toggle end-to-end through EmailArchiver."""
 from __future__ import annotations
 
+import os
 from datetime import datetime
 
 from email_archiver.archiver.archiver import EmailArchiver
 from email_archiver.config import get_date_prefix_enabled
 
 
+class _FakeAttachment:
+    """A real (non-inline) attachment: no MAPI properties, so the archiver's
+    inline detection falls through both branches and saves it."""
+
+    def __init__(self, filename):
+        self.FileName = filename
+
+    @property
+    def PropertyAccessor(self):
+        raise AttributeError("no PropertyAccessor on this fake")
+
+    def SaveAsFile(self, path):  # noqa: N802 - COM-shaped API
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("att")
+
+
 class _FakeAttachments:
+    def __init__(self, items=()):
+        self._items = list(items)
+
     def __iter__(self):
-        return iter(())
+        return iter(self._items)
 
 
 class _FakeMailItem:
-    """Enough of a MailItem for the archiver: dates, SaveAs, no attachments."""
+    """Enough of a MailItem for the archiver: dates, SaveAs, attachments."""
 
-    def __init__(self, sent_on=datetime(2026, 3, 14, 9, 30)):
+    def __init__(self, sent_on=datetime(2026, 3, 14, 9, 30), attachments=()):
         self.SentOn = sent_on
         self.ReceivedTime = None
-        self.Attachments = _FakeAttachments()
+        self.Attachments = _FakeAttachments(
+            _FakeAttachment(n) for n in attachments
+        )
 
     def SaveAs(self, path, fmt):  # noqa: N802 - COM-shaped API
         with open(path, "w", encoding="utf-8") as fh:
@@ -98,6 +120,36 @@ def test_toggle_off_does_not_even_read_the_sent_date(tmp_path):
 
     result = EmailArchiver(_cfg()).archive(_ExplodingDates(), str(tmp_path), "Quiet")
     assert result.email_path.endswith("001 - Quiet.msg")
+
+
+def test_the_whole_bundle_shares_one_prefix_with_the_toggle_off(tmp_path):
+    result = EmailArchiver(_cfg()).archive(
+        _FakeMailItem(attachments=("invoice.pdf", "signed_contract.docx")),
+        str(tmp_path),
+        "Project Alpha",
+    )
+    names = sorted(os.path.basename(p) for p in
+                   [result.email_path, *result.attachment_paths])
+    assert names == [
+        "001 - Project Alpha.msg",
+        "001 - invoice.pdf",
+        "001 - signed_contract.docx",
+    ]
+
+
+def test_the_whole_bundle_shares_one_date_and_seq_with_the_toggle_on(tmp_path):
+    result = EmailArchiver(_cfg(date_prefix=True)).archive(
+        _FakeMailItem(attachments=("invoice.pdf", "signed_contract.docx")),
+        str(tmp_path),
+        "Project Alpha",
+    )
+    names = sorted(os.path.basename(p) for p in
+                   [result.email_path, *result.attachment_paths])
+    assert names == [
+        "2026-03-14 - 001 - Project Alpha.msg",
+        "2026-03-14 - 001 - invoice.pdf",
+        "2026-03-14 - 001 - signed_contract.docx",
+    ]
 
 
 def test_explicit_override_beats_the_config_in_both_directions(tmp_path):

--- a/tests/test_archiver_date_prefix_toggle.py
+++ b/tests/test_archiver_date_prefix_toggle.py
@@ -1,0 +1,137 @@
+"""Tests for the naming.date_prefix toggle end-to-end through EmailArchiver."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from email_archiver.archiver.archiver import EmailArchiver
+from email_archiver.config import get_date_prefix_enabled
+
+
+class _FakeAttachments:
+    def __iter__(self):
+        return iter(())
+
+
+class _FakeMailItem:
+    """Enough of a MailItem for the archiver: dates, SaveAs, no attachments."""
+
+    def __init__(self, sent_on=datetime(2026, 3, 14, 9, 30)):
+        self.SentOn = sent_on
+        self.ReceivedTime = None
+        self.Attachments = _FakeAttachments()
+
+    def SaveAs(self, path, fmt):  # noqa: N802 - COM-shaped API
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("msg")
+
+
+def _cfg(**naming):
+    cfg = {"path": {"max_length": 255}}
+    if naming:
+        cfg["naming"] = naming
+    return cfg
+
+
+# ------------------------------------------------------- config accessor ----
+
+def test_absent_naming_section_defaults_to_off():
+    assert get_date_prefix_enabled({}) is False
+
+
+def test_absent_key_in_present_section_defaults_to_off():
+    assert get_date_prefix_enabled({"naming": {}}) is False
+
+
+def test_explicit_true_is_on():
+    assert get_date_prefix_enabled({"naming": {"date_prefix": True}}) is True
+
+
+def test_explicit_false_is_off():
+    assert get_date_prefix_enabled({"naming": {"date_prefix": False}}) is False
+
+
+# ------------------------------------------------------------- archiving ----
+
+def test_default_config_writes_the_undated_form(tmp_path):
+    result = EmailArchiver(_cfg()).archive(
+        _FakeMailItem(), str(tmp_path), "Project Alpha meeting notes"
+    )
+    assert result.sequence_number == "001"
+    assert result.email_path.endswith("001 - Project Alpha meeting notes.msg")
+
+
+def test_toggle_on_writes_the_dated_form(tmp_path):
+    result = EmailArchiver(_cfg(date_prefix=True)).archive(
+        _FakeMailItem(), str(tmp_path), "Project Alpha meeting notes"
+    )
+    assert result.email_path.endswith(
+        "2026-03-14 - 001 - Project Alpha meeting notes.msg"
+    )
+
+
+def test_toggle_on_with_no_resolvable_date_falls_back_to_undated(tmp_path, caplog):
+    with caplog.at_level("WARNING"):
+        result = EmailArchiver(_cfg(date_prefix=True)).archive(
+            _FakeMailItem(sent_on=None), str(tmp_path), "No date here"
+        )
+    assert result.email_path.endswith("001 - No date here.msg")
+    assert any("sent date" in rec.message for rec in caplog.records)
+
+
+def test_toggle_off_does_not_even_read_the_sent_date(tmp_path):
+    # The date must not be consulted when the toggle is off: an item whose date
+    # properties explode would otherwise fail an archive that never needed them.
+    class _ExplodingDates:
+        Attachments = _FakeAttachments()
+
+        @property
+        def SentOn(self):  # noqa: N802 - COM-shaped API
+            raise AssertionError("SentOn must not be read when the toggle is off")
+
+        @property
+        def ReceivedTime(self):  # noqa: N802 - COM-shaped API
+            raise AssertionError("ReceivedTime must not be read when the toggle is off")
+
+        def SaveAs(self, path, fmt):  # noqa: N802 - COM-shaped API
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("msg")
+
+    result = EmailArchiver(_cfg()).archive(_ExplodingDates(), str(tmp_path), "Quiet")
+    assert result.email_path.endswith("001 - Quiet.msg")
+
+
+def test_explicit_override_beats_the_config_in_both_directions(tmp_path):
+    # The dialog's checkbox passes its state through this override, so a ticked
+    # box must win over a config saying off, and an unticked box over one on.
+    on = EmailArchiver(_cfg(), date_prefix=True).archive(
+        _FakeMailItem(), str(tmp_path / "a"), "Ticked"
+    )
+    assert on.email_path.endswith("2026-03-14 - 001 - Ticked.msg")
+
+    off = EmailArchiver(_cfg(date_prefix=True), date_prefix=False).archive(
+        _FakeMailItem(), str(tmp_path / "b"), "Unticked"
+    )
+    assert off.email_path.endswith("001 - Unticked.msg")
+
+
+def test_override_none_defers_to_the_config(tmp_path):
+    result = EmailArchiver(_cfg(date_prefix=True), date_prefix=None).archive(
+        _FakeMailItem(), str(tmp_path), "Deferred"
+    )
+    assert result.email_path.endswith("2026-03-14 - 001 - Deferred.msg")
+
+
+def test_toggle_off_still_continues_a_dated_folders_sequence(tmp_path):
+    # Flipping the toggle off in a folder already holding dated files must not
+    # restart the sequence at 001 and collide.
+    (tmp_path / "2026-03-14 - 007 - earlier.msg").write_text("x")
+    result = EmailArchiver(_cfg()).archive(_FakeMailItem(), str(tmp_path), "Next one")
+    assert result.email_path.endswith("008 - Next one.msg")
+
+
+def test_toggle_on_still_continues_an_undated_folders_sequence(tmp_path):
+    (tmp_path / "012 - earlier.msg").write_text("x")
+    result = EmailArchiver(_cfg(date_prefix=True)).archive(
+        _FakeMailItem(), str(tmp_path), "Next one"
+    )
+    assert result.email_path.endswith("2026-03-14 - 013 - Next one.msg")

--- a/tests/test_archiver_path_fit.py
+++ b/tests/test_archiver_path_fit.py
@@ -76,7 +76,7 @@ def test_date_prefix_accounted_for_in_truncation_budget():
     assert _ELLIPSIS + ".msg" in name
 
 
-def test_no_date_prefix_falls_back_to_legacy_form():
+def test_no_date_prefix_uses_the_default_undated_form():
     folder = r"C:\Users\me\OneDrive\Archive\Project Alpha"
     name = _fit_filename_to_path(
         folder, "042", "meeting_notes_q4", ".msg", date_prefix=None

--- a/tests/test_archiver_sequencing.py
+++ b/tests/test_archiver_sequencing.py
@@ -34,7 +34,7 @@ def test_empty_folder_starts_at_001(tmp_path):
     assert get_next_sequence_number(str(tmp_path)) == "001"
 
 
-def test_legacy_only_folder_picks_max_plus_one(tmp_path):
+def test_undated_only_folder_picks_max_plus_one(tmp_path):
     (tmp_path / "001 - alpha.msg").write_text("x")
     (tmp_path / "007 - beta.pdf").write_text("x")
     assert get_next_sequence_number(str(tmp_path)) == "008"
@@ -46,7 +46,7 @@ def test_dated_only_folder_picks_max_plus_one(tmp_path):
     assert get_next_sequence_number(str(tmp_path)) == "013"
 
 
-def test_mixed_legacy_and_dated_folder_never_collides(tmp_path):
+def test_mixed_undated_and_dated_folder_never_collides(tmp_path):
     (tmp_path / "023 - old_email.msg").write_text("x")
     (tmp_path / "2026-03-14 - 024 - new_email.msg").write_text("x")
     assert get_next_sequence_number(str(tmp_path)) == "025"

--- a/tests/test_explorer_pick.py
+++ b/tests/test_explorer_pick.py
@@ -1,7 +1,10 @@
 """Tests for the Explorer-window pick — the pure half, no COM required."""
 from __future__ import annotations
 
-from email_archiver.explorer import pick_foremost_folder
+import pytest
+
+import email_archiver.explorer as explorer
+from email_archiver.explorer import ExplorerUnavailableError, pick_foremost_folder
 
 
 def test_no_eligible_windows_returns_none():
@@ -33,3 +36,21 @@ def test_falls_back_to_newest_window_when_z_order_has_no_match():
     # the last-enumerated (newest) window is the closest stand-in.
     folders = {111: r"E:\archive\old", 222: r"E:\archive\newest"}
     assert pick_foremost_folder(folders, []) == r"E:\archive\newest"
+
+
+# ------------------------------------- unreachable shell vs nothing open ----
+
+def test_nothing_open_is_a_real_answer_of_none(monkeypatch):
+    monkeypatch.setattr(explorer, "_enumerate_explorer_folders", dict)
+    assert explorer.get_current_explorer_folder() is None
+
+
+def test_unreachable_shell_raises_rather_than_reading_as_nothing_open(monkeypatch):
+    # Failing to establish the fact must not be folded into "nothing is open" —
+    # they lead the user to two different fixes.
+    def boom():
+        raise OSError("COM server unavailable")
+
+    monkeypatch.setattr(explorer, "_enumerate_explorer_folders", boom)
+    with pytest.raises(ExplorerUnavailableError):
+        explorer.get_current_explorer_folder()

--- a/tests/test_explorer_pick.py
+++ b/tests/test_explorer_pick.py
@@ -1,0 +1,35 @@
+"""Tests for the Explorer-window pick — the pure half, no COM required."""
+from __future__ import annotations
+
+from email_archiver.explorer import pick_foremost_folder
+
+
+def test_no_eligible_windows_returns_none():
+    assert pick_foremost_folder({}, [111, 222]) is None
+
+
+def test_single_window_wins():
+    assert pick_foremost_folder({222: r"E:\archive\alpha"}, [999, 222]) == r"E:\archive\alpha"
+
+
+def test_highest_z_order_window_wins_not_the_first_enumerated():
+    # The shell enumerates roughly oldest-first; the user's foremost window is
+    # the one highest in the z-order, which here is the *second* enumerated.
+    folders = {111: r"E:\archive\old", 222: r"E:\archive\current"}
+    z_order = [222, 111]
+    assert pick_foremost_folder(folders, z_order) == r"E:\archive\current"
+
+
+def test_non_explorer_windows_in_the_z_order_are_ignored():
+    # The archive dialog itself is topmost but is not an Explorer window, so it
+    # never appears in the eligible mapping and must not block the pick.
+    folders = {111: r"E:\archive\alpha"}
+    z_order = [900, 901, 111]
+    assert pick_foremost_folder(folders, z_order) == r"E:\archive\alpha"
+
+
+def test_falls_back_to_newest_window_when_z_order_has_no_match():
+    # A minimised or racing window can be missing from the z-order snapshot;
+    # the last-enumerated (newest) window is the closest stand-in.
+    folders = {111: r"E:\archive\old", 222: r"E:\archive\newest"}
+    assert pick_foremost_folder(folders, []) == r"E:\archive\newest"


### PR DESCRIPTION
## Summary

Two corrections to what #41 shipped, plus the archive-destination escape hatch the rewrite dropped.

**Naming default reverted to `NNN - <name>`.** #41 made `YYYY-MM-DD - NNN - ` unconditional. The shorter form is the one wanted day to day — more `MAX_PATH` headroom in deep folders, and the date is already inside the `.msg`.

**The date prefix is now opt-in, two ways.** A **Date prefix (YYYY-MM-DD)** checkbox in the archive dialog's bottom bar applies it to one archive without touching config; `naming.date_prefix` (default `false`) sets that checkbox's *starting* position. `EmailArchiver` takes the checkbox state as an explicit keyword override, so precedence is checkbox → config → built-in default. Everything else about the dated form is unchanged from #41 — sent date in local time, attachments inherit the parent's date, unresolvable date falls back to undated and logs why, path-fitter accounts for the extra 13 chars only when they are applied.

Sequence allocation reads **both** prefix forms regardless of which one is being written, so the toggle is safe to flip in a folder holding a mix and can never allocate a colliding number.

**New `Explorer folder` button, immediately left of `Cancel`.** Archives straight into the folder shown in the foremost open File Explorer window — restoring what the pre-2026 `email-automation-save.py` did and the rewrite never carried over. Picks by window z-order (the one you looked at last), skips virtual shell locations and non-Explorer shell windows, is deliberately not limited to the configured archive roots, and routes through the same `_do_archive` as a suggestion click. The z-order pick is a pure function so it is testable without COM.

A failure to reach the shell raises `ExplorerUnavailableError` and gets its own dialog rather than being folded into "no Explorer window is open" — two different situations pointing at two different fixes.

## Validation

**Gate** — `py_compile` over `email_archiver/*.py email_archiver/*/*.py tests/*.py`: clean. `pytest tests -q`: **47 passed**, 0 failures, 0 skips. No CI workflows exist in this repo, so the local gate is the whole gate.

**Reproduction proof (before/after, same probe against a real `EmailArchiver.archive`)** — on `main`: `2026-03-14 - 001 - Project Alpha meeting notes.msg`. On this branch: `001 - Project Alpha meeting notes.msg`. The new behaviour tests were confirmed to fail against pre-fix code before being counted.

**Behavioural — real Outlook email, real Explorer windows, real files on disk**

| What was driven | Result |
|---|---|
| Checkbox unticked (default), archived via `Explorer folder` | `001 - records i una abr_ada.msg` in the live Explorer folder |
| Checkbox ticked, same flow | `2026-08-23 - 001 - records i una abr_ada.msg` — the email's sent date |
| Folder pre-seeded with `2026-01-01 - 041 - seeded.msg`, toggle off | next file written as `042 - …` — mixed-form folder, no collision |
| Three Explorer windows opened in sequence | each newly-foremost one returned in turn |
| *This PC* brought foremost | skipped; fell through to the real folder behind it |
| No eligible window (enumeration forced empty) | `None` + the "open a folder in Explorer" dialog, nothing archived |

**Diff sweep** — no dependency changes, no removed tests, no weakened assertions, no `.gitignore` edits, nothing outside the stated scope.

**Independent review** — a fresh agent with no context on the build fetched the acceptance criteria itself, read the diff, re-ran the gate independently (clean compile, tests green on its own run), and probed the z-order pick live in a separate environment: with two Explorer windows at `EnumWindows` indices 22 and 69, the index-22 one won, confirming a true z-order pick rather than shell-enumeration order. Verdict `pass: true`. Its one substantive nit — an unreachable shell reading as "nothing open" — is fixed in `0de397e` rather than deferred.

## Docs

`README.md` leads with the `NNN - ` default, documents the optional prefix both ways and the two bottom-bar escapes; `config/config.example.yaml` carries `naming.date_prefix: false`; `docs/architecture.mmd` gains the `explorer.py` node and the checkbox on the dialog → archiver edge, per this repo's `CLAUDE.md` same-PR contract.

Closes #40