### PR TITLE
docs: document test suite, verification gate, and fix stale rotating-log claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,11 @@ See `README.md` for setup, layout, and usage.
 ## Internal architecture
 
 [`docs/architecture.mmd`](docs/architecture.mmd) is a hand-authored Mermaid diagram of this repo's own internal structure — the entry points, the `email_archiver/` modules (scanner, database, outlook, engine, archiver, ui), and how a scan/archive email flows between them. Update it in the same PR as any material structural change (a module added/moved/renamed, a new entry point, a data-flow change) — same anti-staleness contract as a `.fleet.toml` `description` field.
+
+## Verification
+
+```powershell
+& .\.venv\Scripts\python.exe -m pytest tests/
+```
+
+`pytest` is a dev-only dependency (declared in `requirements.txt`). Don't claim a change works without running this gate.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ archiver/
 │   └── emails.db                ← SQLite database (auto-created on first scan)
 │
 ├── logs/
-│   └── archiver.log             ← Rotating log file
+│   └── archiver.log             ← Log file (plain FileHandler, not rotated)
 │
 ├── email_archiver/              ← Main package
 │   ├── config.py                ← YAML loader, path resolution, logging setup
@@ -127,6 +127,10 @@ archiver/
 │   └── ui/
 │       ├── app.py              ← ArchiveDialog, ScanWindow, LauncherApp
 │       └── dialogs.py          ← Native folder-picker wrapper
+│
+├── tests/                       ← pytest suite (filename fitting, sequencing, date-prefix toggle, Explorer picker, is_running regression)
+├── docs/
+│   └── architecture.mmd         ← Hand-authored Mermaid diagram of internal structure
 │
 ├── main_archive.py              ← Stream Deck entry: Archive Email
 ├── main_scan.py                 ← Stream Deck entry: Scan Archive
@@ -229,6 +233,18 @@ The `.bat` files use `pythonw` so no console window flashes on screen.
 # Full launcher with both buttons + DB stats
 & .\.venv\Scripts\python.exe main_ui.py
 ```
+
+---
+
+## Verification
+
+The project ships a pytest suite (`tests/`) covering the filename fitter, sequencing, the date-prefix toggle, the Explorer picker, and the `is_running()` regression. Run it before declaring any change done:
+
+```powershell
+& .\.venv\Scripts\python.exe -m pytest tests/
+```
+
+`pytest` is a dev-only dependency — see `requirements.txt`.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,6 @@ rapidfuzz>=3.0
 
 # Optional: faster process list for is_running() check
 psutil>=5.9
+
+# Dev dependency: test suite (tests/) – not required at runtime
+pytest>=8.0


### PR DESCRIPTION
## Summary

Closes the two documentation findings surfaced by `/codebase-audit`:

- The repo ships a 47-test pytest suite (`tests/`) that no document mentioned. `README.md`'s project-structure tree now lists `tests/` and `docs/`, a new "Verification" section documents the `pytest tests/` command, and `pytest` is declared as a dev dependency in `requirements.txt`. `CLAUDE.md` gains a matching `## Verification` section so the fleet's "verify before declaring done" rule has something concrete to point at in this repo.
- `README.md`'s project-structure tree claimed `logs/archiver.log` is a "Rotating log file". `config.setup_logging` installs a plain `logging.FileHandler` — nothing rotates. The annotation now says so.

## Validation

`& .\.venv\Scripts\python.exe -m pytest tests/` — 47 passed, 0 failures. No CI workflows exist in this repo, so the local gate is the whole gate. `/e2e` routing: `WEB_SURFACE=no`, `SUITE=absent` — n/a, no e2e suite applicable to this desktop app; deterministic pytest is the coverage here. Docs-only diff (`CLAUDE.md`, `README.md`, `requirements.txt`) — no code paths touched.

Closes #46