### PR TITLE
chore: remove dead folder-count and email-body code paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,10 @@ CREATE VIRTUAL TABLE emails_fts USING fts5(
     tokenize = 'unicode61 remove_diacritics 1'
 );
 
--- Aggregated folder stats (used by suggestion engine)
+-- Plain registry of folders the scanner has seen
 CREATE TABLE folders (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     folder_path  TEXT UNIQUE NOT NULL,
-    email_count  INTEGER NOT NULL DEFAULT 0,
     last_updated TEXT NOT NULL DEFAULT (datetime('now'))
 );
 ```

--- a/email_archiver/database/models.py
+++ b/email_archiver/database/models.py
@@ -5,8 +5,9 @@ Design notes:
 - SQLite FTS5 is used for full-text search over subject/sender/recipients/body.
   FTS5 is built into Python's sqlite3 on Windows; no extra dependency needed.
 - Triggers keep the FTS index in sync with the emails table automatically.
-- The folders table is a denormalized summary updated by the scanner for fast
-  folder-level scoring in the suggestion engine.
+- The folders table is a plain registry of folders the scanner has seen
+  (path + last-scanned timestamp); the suggestion engine scores folders by
+  aggregating per-email FTS matches in Python, not by reading this table.
 - WAL journal mode allows concurrent reads during a long scan without blocking
   the archive command.
 """
@@ -72,11 +73,10 @@ AFTER UPDATE ON emails BEGIN
 END;
 
 -- --------------------------------------------------------------- folders ---
--- Aggregated per-folder stats used by the suggestion engine for scoring.
+-- Plain registry of folders the scanner has seen (path + last-scanned time).
 CREATE TABLE IF NOT EXISTS folders (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     folder_path  TEXT    UNIQUE NOT NULL,
-    email_count  INTEGER NOT NULL DEFAULT 0,
     last_updated TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -101,7 +101,7 @@ class EmailRepository:
         )
 
     def upsert_folder(self, folder_path: str) -> None:
-        """Upsert folder record; email_count is refreshed separately."""
+        """Upsert folder record's last-seen timestamp."""
         self._conn.execute(
             """
             INSERT INTO folders (folder_path, last_updated)
@@ -110,17 +110,6 @@ class EmailRepository:
                 last_updated = datetime('now')
             """,
             (folder_path,),
-        )
-
-    def refresh_folder_counts(self) -> None:
-        """Recompute email_count for all folders from the emails table."""
-        self._conn.execute(
-            """
-            UPDATE folders SET email_count = (
-                SELECT COUNT(*) FROM emails
-                WHERE emails.folder_path = folders.folder_path
-            )
-            """
         )
 
     def delete_missing_emails(self, known_paths: Sequence[str]) -> int:
@@ -137,9 +126,6 @@ class EmailRepository:
             known_paths,
         )
         return cur.rowcount
-
-    def commit(self) -> None:
-        self._conn.commit()
 
     # -------------------------------------------------- read operations ----
 

--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -30,7 +30,6 @@ class EmailData:
     sender: str = ""
     recipients: str = ""           # semicolon-separated SMTP addresses
     date_sent: datetime | None = None
-    body: str = ""
     raw_item: Any = None           # the COM MailItem – only used by archiver
 
 
@@ -244,7 +243,6 @@ class OutlookClient:
                 sender=_get_sender_smtp(item),
                 recipients=_get_recipients_smtp(item),
                 date_sent=date_sent,
-                body=item.Body[:2000] if item.Body else "",
                 raw_item=item,
             )
 

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -227,9 +227,6 @@ class FolderScanner:
                 logger.info("Purged %d deleted email(s) from index.", stats.deleted)
             conn.commit()
 
-        repo.refresh_folder_counts()
-        conn.commit()
-
         stats.duration_seconds = (datetime.now() - start).total_seconds()
         logger.info(
             "Scan complete: %d new, %d updated, %d skipped, %d errors in %.1fs",


### PR DESCRIPTION
## Summary

Closes the three stale-code findings surfaced by \`/codebase-audit\` (#44):

- \`folders.email_count\` + \`EmailRepository.refresh_folder_counts()\` existed for a suggestion-engine consumer that was never built — \`suggest_folders\` aggregates per-folder scores in Python from the \`emails\` rows and never touches the \`folders\` table. Dropped the column and the method (and the full-table correlated \`UPDATE\` scanner.py ran on every scan to maintain it); corrected the stale claim in \`models.py\`'s docstring and \`README.md\`'s schema comment.
- \`EmailData.body\` was populated with a COM property read (\`item.Body[:2000]\`) on the archive dialog's startup path and never consumed — \`SuggestionEngine.suggest\` only passes subject/sender/recipients to \`suggest_folders\`. Dropped the field and the read, removing a per-launch COM round-trip on the path README advertises as "under two seconds".
- \`EmailRepository.commit()\` had no callers — the scanner commits through \`conn.commit()\` directly. Deleted it rather than rerouting the scanner's four commit sites, since none of them cross the repository boundary today.

## Validation

\`& .\.venv\Scripts\python.exe -m pytest tests/\` — 47 passed, 0 failures. No CI workflows exist in this repo, so the local gate is the whole gate. \`/e2e\` routing: \`WEB_SURFACE=no\`, \`SUITE=absent\` — n/a, no e2e suite applicable to this desktop app; deterministic pytest is the coverage here. No UX surface touched (non-web repo).

Closes #44