### PR TITLE
fix: bound the attachment dedupe loop and the delete-missing purge

### DIFF
--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -58,6 +58,12 @@ _RE_UNDATED_PREFIX = re.compile(r"^(\d{3}) - ")
 # ``config.DEFAULT_MAX_PATH_LENGTH`` for the rationale behind the value.
 _ELLIPSIS = "..."
 
+# Bound on the attachment de-duplication loop in ``_save_attachments`` — a
+# fitter regression (or a pathological folder with dozens of same-name
+# attachments already saved) degrades to a logged, skipped attachment instead
+# of hanging the caller's thread forever.
+_MAX_DEDUPE_ATTEMPTS = 100
+
 
 # ----------------------------------------------------------------- types ----
 
@@ -343,16 +349,35 @@ class EmailArchiver:
                 )
                 att_path = os.path.join(folder_path, att_filename)
                 # Avoid overwrite if multiple attachments share the same name.
-                # The disambiguation suffix is folded into the stem before fitting,
-                # so the final path still respects the Windows MAX_PATH budget.
+                # The disambiguating counter is appended to the *suffix* (not
+                # folded into the stem) so its width comes out of the stem's
+                # fit budget on every iteration via the normal `fixed` term —
+                # folding it into the stem instead left `stem_budget` (which
+                # depends only on folder/prefix/suffix length, never the
+                # stem) unchanged across iterations, so once truncation
+                # kicked in every attempt truncated to the exact same
+                # characters and `os.path.exists` never went False (#43).
+                # Bounded so a fitter regression degrades to a logged, skipped
+                # attachment instead of hanging the caller's thread.
                 counter = 2
                 while os.path.exists(att_path):
+                    if counter > _MAX_DEDUPE_ATTEMPTS:
+                        logger.error(
+                            "Could not find a non-colliding filename for "
+                            "attachment %r in %s after %d attempts; skipping",
+                            original_name, folder_path, _MAX_DEDUPE_ATTEMPTS,
+                        )
+                        att_path = None
+                        break
                     att_filename = _fit_filename_to_path(
-                        folder_path, seq, f"{stem}_{counter}", suffix,
+                        folder_path, seq, stem, f"_{counter}{suffix}",
                         date_prefix=date_prefix, max_path=self._max_path,
                     )
                     att_path = os.path.join(folder_path, att_filename)
                     counter += 1
+
+                if att_path is None:
+                    continue
 
                 attachment.SaveAsFile(att_path)
                 saved.append(att_path)

--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -117,14 +117,30 @@ class EmailRepository:
         Remove DB entries whose files no longer exist on disk.
         Called at the end of a full scan to purge deleted emails.
         Returns the number of rows deleted.
+
+        Goes via a temp table rather than binding one SQL parameter per known
+        path: SQLite's ``SQLITE_LIMIT_VARIABLE_NUMBER`` is 32,766, so a
+        one-placeholder-per-file query raises ``OperationalError: too many SQL
+        variables`` once the archive passes that many files -- after the
+        indexing pass has already completed, aborting the purge (#43). The
+        temp table keeps this independent of file count; caller commits (same
+        pattern as ``upsert_email``/``upsert_folder``).
         """
         if not known_paths:
             return 0
-        placeholders = ",".join("?" * len(known_paths))
-        cur = self._conn.execute(
-            f"DELETE FROM emails WHERE file_path NOT IN ({placeholders})",
-            known_paths,
+        self._conn.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS tmp_known_paths (path TEXT PRIMARY KEY)"
         )
+        self._conn.execute("DELETE FROM tmp_known_paths")
+        self._conn.executemany(
+            "INSERT INTO tmp_known_paths (path) VALUES (?)",
+            [(p,) for p in known_paths],
+        )
+        cur = self._conn.execute(
+            "DELETE FROM emails WHERE file_path NOT IN "
+            "(SELECT path FROM tmp_known_paths)"
+        )
+        self._conn.execute("DROP TABLE tmp_known_paths")
         return cur.rowcount
 
     # -------------------------------------------------- read operations ----

--- a/tests/test_archiver_attachment_dedupe.py
+++ b/tests/test_archiver_attachment_dedupe.py
@@ -1,0 +1,133 @@
+"""Regression tests for the attachment de-duplication loop (issue #43).
+
+``_fit_filename_to_path``'s truncation branch computes ``stem_budget`` from
+the folder/prefix/suffix lengths only -- never from the stem itself. Folding
+the disambiguating counter into the *stem* (the old behaviour) therefore
+produced a byte-identical truncated filename on every iteration once
+truncation kicked in, so ``while os.path.exists(att_path):`` never saw the
+path stop existing and spun forever on the Tk main thread. The fix appends
+the counter to the *suffix* instead (its width is then reserved out of the
+stem budget via the existing ``fixed`` term) and bounds the loop at
+``_MAX_DEDUPE_ATTEMPTS``.
+
+Every test here runs the archiver call on a background thread with a bounded
+``join(timeout=...)`` so a regression fails fast with a clear assertion
+instead of hanging the test run itself.
+"""
+from __future__ import annotations
+
+import os
+import threading
+
+from email_archiver.archiver.archiver import (
+    _MAX_DEDUPE_ATTEMPTS,
+    _fit_filename_to_path,
+    EmailArchiver,
+)
+
+
+class _FakeAttachment:
+    """A real (non-inline) attachment: no MAPI properties, so the archiver's
+    inline detection falls through both branches and saves it."""
+
+    def __init__(self, filename):
+        self.FileName = filename
+
+    @property
+    def PropertyAccessor(self):
+        raise AttributeError("no PropertyAccessor on this fake")
+
+    def SaveAsFile(self, path):  # noqa: N802 - COM-shaped API
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("att")
+
+
+class _FakeAttachments:
+    def __init__(self, items=()):
+        self._items = list(items)
+
+    def __iter__(self):
+        return iter(self._items)
+
+
+class _FakeMailItem:
+    def __init__(self, attachments=()):
+        self.Attachments = _FakeAttachments(
+            _FakeAttachment(n) for n in attachments
+        )
+
+    def SaveAs(self, path, fmt):  # noqa: N802 - COM-shaped API
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("msg")
+
+
+def _run_bounded(target, *, timeout=10.0):
+    """Run ``target`` on a daemon thread; assert it returned within ``timeout``."""
+    t = threading.Thread(target=target, daemon=True)
+    t.start()
+    t.join(timeout=timeout)
+    assert not t.is_alive(), (
+        "attachment de-dupe loop did not return within the bounded timeout "
+        "-- the collision loop is hanging again (#43)"
+    )
+
+
+def test_attachments_that_truncate_to_the_same_stem_get_distinct_names(tmp_path):
+    # Force the truncation branch deterministically by capping max_path just
+    # past folder + prefix + suffix, regardless of tmp_path's own length --
+    # only a handful of stem chars fit, so two attachments whose stems share
+    # a long common prefix collide once truncated.
+    folder = str(tmp_path)
+    max_path = len(folder) + 1 + len("007 - ") + len(".pdf") + 5
+    cfg = {"path": {"max_length": max_path}}
+
+    mail_item = _FakeMailItem(attachments=(
+        "Quarterly_report_2026_meeting_notes_Q1.pdf",
+        "Quarterly_report_2026_meeting_notes_Q2.pdf",
+    ))
+    archiver = EmailArchiver(cfg)
+
+    result_holder = {}
+
+    def run():
+        result_holder["result"] = archiver.archive(mail_item, folder, "Subject")
+
+    _run_bounded(run)
+
+    result = result_holder["result"]
+    names = [os.path.basename(p) for p in result.attachment_paths]
+    assert len(names) == 2
+    assert len(set(names)) == 2, f"attachments collided on disk: {names}"
+    for name in names:
+        assert os.path.exists(os.path.join(folder, name))
+
+
+def test_dedupe_loop_caps_out_and_skips_instead_of_hanging(tmp_path, caplog):
+    folder = str(tmp_path)
+    seq = "007"
+    stem = "report"
+    suffix = ".pdf"
+
+    # Pre-occupy the base name and every disambiguated variant up to (and one
+    # past) the bounded cap, so the real attempt below is forced to exhaust
+    # every attempt and give up rather than ever finding a free name.
+    (tmp_path / _fit_filename_to_path(folder, seq, stem, suffix)).write_bytes(b"x")
+    for counter in range(2, _MAX_DEDUPE_ATTEMPTS + 2):
+        name = _fit_filename_to_path(folder, seq, stem, f"_{counter}{suffix}")
+        (tmp_path / name).write_bytes(b"x")
+
+    mail_item = _FakeMailItem(attachments=(f"{stem}{suffix}",))
+    archiver = EmailArchiver({"path": {"max_length": 255}})
+
+    result_holder = {}
+
+    def run():
+        result_holder["paths"] = archiver._save_attachments(mail_item, folder, seq, None)
+
+    with caplog.at_level("ERROR"):
+        _run_bounded(run)
+
+    assert result_holder["paths"] == []
+    assert any(
+        "non-colliding filename" in rec.message for rec in caplog.records
+    ), "expected an error log breadcrumb when the dedupe cap is exceeded"

--- a/tests/test_repository_delete_missing.py
+++ b/tests/test_repository_delete_missing.py
@@ -1,0 +1,70 @@
+"""Regression tests for ``EmailRepository.delete_missing_emails`` (issue #43).
+
+The old implementation bound one SQL parameter per known path, which raises
+``sqlite3.OperationalError: too many SQL variables`` once the archive holds
+more files than SQLite's ``SQLITE_LIMIT_VARIABLE_NUMBER`` (32,766) -- after
+the entire indexing pass has already run, aborting the purge. The fix routes
+through a temp table instead, independent of file count.
+"""
+from __future__ import annotations
+
+from email_archiver.database.models import init_db
+from email_archiver.database.repository import EmailRecord, EmailRepository
+
+
+def _repo(tmp_path):
+    conn = init_db(str(tmp_path / "emails.db"))
+    return EmailRepository(conn), conn
+
+
+def _seed(repo, file_path):
+    repo.upsert_email(
+        EmailRecord(
+            file_path=file_path,
+            folder_path="C:/archive",
+            filename=file_path,
+            file_mtime=1.0,
+        )
+    )
+
+
+def test_deletes_only_rows_missing_from_known_paths(tmp_path):
+    repo, conn = _repo(tmp_path)
+    _seed(repo, "a.msg")
+    _seed(repo, "b.msg")
+    conn.commit()
+
+    deleted = repo.delete_missing_emails(["a.msg"])
+    conn.commit()
+
+    assert deleted == 1
+    assert repo.get_mtime("a.msg") == 1.0
+    assert repo.get_mtime("b.msg") is None
+
+
+def test_empty_known_paths_is_a_no_op(tmp_path):
+    repo, conn = _repo(tmp_path)
+    _seed(repo, "a.msg")
+    conn.commit()
+
+    assert repo.delete_missing_emails([]) == 0
+    assert repo.get_mtime("a.msg") == 1.0
+
+
+def test_survives_more_known_paths_than_sqlites_variable_limit(tmp_path):
+    # SQLITE_LIMIT_VARIABLE_NUMBER is 32766 in the shipped 3.50.4 build --
+    # the pre-fix query raised OperationalError past that many bound
+    # parameters. Only a couple of real rows are needed; the rest of the
+    # list just has to push the count past the limit.
+    repo, conn = _repo(tmp_path)
+    _seed(repo, "keep.msg")
+    _seed(repo, "gone.msg")
+    conn.commit()
+
+    known_paths = ["keep.msg"] + [f"synthetic_{i}.msg" for i in range(40_000)]
+    deleted = repo.delete_missing_emails(known_paths)
+    conn.commit()
+
+    assert deleted == 1
+    assert repo.get_mtime("keep.msg") == 1.0
+    assert repo.get_mtime("gone.msg") is None


### PR DESCRIPTION
## Summary

Closes both audit-surfaced bug findings (#43):

- \`_save_attachments\` folded its disambiguating counter into the stem before fitting to \`MAX_PATH\`; once truncation kicked in, \`stem_budget\` depends only on folder/prefix/suffix length (never the stem), so every counter produced a byte-identical filename and the \`while\` loop spun forever on the Tk main thread. Appended the counter to the suffix instead, so each iteration's fit budget actually differs, and capped the loop so a fitter regression degrades to a logged, skipped attachment rather than a hang.
- \`delete_missing_emails\` bound one SQL parameter per known file path, which raises sqlite3's "too many SQL variables" once an archive passes \`SQLITE_LIMIT_VARIABLE_NUMBER\` (32,766) files -- after the whole scan has already run, aborting the purge uncaught. Routed through a temp table instead so the purge is independent of file count.

## Validation

\`& .\.venv\Scripts\python.exe -m pytest tests/\` — 52 passed, 0 failures (includes new regression coverage in \`test_archiver_attachment_dedupe.py\` and \`test_repository_delete_missing.py\`). No CI workflows exist in this repo, so the local gate is the whole gate. \`/e2e\` routing: \`WEB_SURFACE=no\`, \`SUITE=absent\` — n/a, no e2e suite applicable to this desktop app; deterministic pytest is the coverage here. No UX surface touched (non-web repo).

Closes #43