### PR TITLE
feat: record the Outlook follow-up flag while scanning

### DIFF
--- a/.fleet.toml
+++ b/.fleet.toml
@@ -4,5 +4,5 @@
 # description, exposed services). Schema: fleet-config/architecture/README.md.
 layer       = "working-pipe"
 icon        = "📧"
-description = "Outlook → OneDrive archive."
+description = "Outlook → OneDrive archive. Its SQLite index records the follow-up flag, which task-os polls read-only to raise a task per flagged mail."
 tag         = ["→", "OneDrive"]

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ CREATE TABLE emails (
     date_sent    TEXT,                   -- ISO-8601
     body_preview TEXT,                   -- first 500 chars of plain text
     file_mtime   REAL NOT NULL,          -- for incremental scan (os.stat)
-    indexed_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    indexed_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    flag_status  INTEGER                  -- Outlook follow-up flag; see below
 );
 
 -- FTS5 full-text index (kept in sync via triggers)
@@ -308,6 +309,17 @@ CREATE TABLE folders (
 The FTS5 index is automatically kept in sync with the `emails` table via `AFTER INSERT`, `AFTER UPDATE`, and `AFTER DELETE` triggers — no manual maintenance needed.
 
 WAL journal mode is enabled so the archive command can read the DB while a scan is running in another process without blocking.
+
+### The follow-up flag (`flag_status`)
+
+`flag_status` records Outlook's follow-up flag, read from the archived `.msg` as MAPI `PidTagFlagStatus` (`0x1090`): **2** = flagged for follow-up, **1** = flagged then completed, **0** = read, and not flagged. It exists so other tools can turn a flagged mail into a task — task-os polls it read-only and raises one Inbox task per flagged message.
+
+Two things about it are easy to get wrong:
+
+- **Flag first, then archive.** The flag is written into the `.msg` at archive time, by the same `SaveAs` call that creates the file. The archived file is a snapshot: flagging a message in Outlook *after* it has been archived changes nothing on disk, and no re-scan will see it.
+- **`NULL` is not `0`.** A row indexed before this column existed reads `NULL`, meaning *the property was never read* — a different fact from `0`, *read, and not flagged*. Existing rows keep `NULL` until their file changes and is re-indexed. That is deliberate and costs nothing: Outlook does not preserve the flag through filing, so an already-archived backlog carries no flags to find (a random sample of 600 of ~18k archived files found none).
+
+The column is added to an existing database automatically on the next run — `init_db` ALTERs in any column the `emails` table is missing, because its `CREATE TABLE IF NOT EXISTS` is a no-op once the table exists.
 
 ---
 

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -39,7 +39,7 @@ flowchart TB
   EXPLORER -->|Shell.Application / EnumWindows| SHELLCOM["Windows shell\n(open File Explorer windows)"]
 
   subgraph scan["Scan Archive data flow"]
-    SCANNER["scanner/scanner.py\nFolderScanner — incremental os.walk,\nmtime compare, batch commits"]
+    SCANNER["scanner/scanner.py\nFolderScanner — incremental os.walk,\nmtime compare, batch commits,\nreads the Outlook follow-up flag"]
   end
   SCANWINDOW --> SCANNER
   MAINSCAN -->|--no-ui| SCANNER
@@ -49,7 +49,7 @@ flowchart TB
 
   subgraph db["email_archiver/database/"]
     REPO["repository.py: EmailRepository\nall SQL — upsert_email, upsert_folder,\nsuggest_folders (FTS5 BM25 query)"]
-    MODELS["models.py\nDDL — emails table, emails_fts (FTS5),\nfolders table, sync triggers, get_connection/init_db"]
+    MODELS["models.py\nDDL — emails table, emails_fts (FTS5),\nfolders table, sync triggers, get_connection/init_db,\nALTERs in columns an older emails table lacks"]
   end
   SCANNER --> REPO
   REPO --> MODELS

--- a/email_archiver/database/models.py
+++ b/email_archiver/database/models.py
@@ -13,8 +13,11 @@ Design notes:
 """
 from __future__ import annotations
 
+import logging
 import sqlite3
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 _DDL = """
@@ -34,7 +37,8 @@ CREATE TABLE IF NOT EXISTS emails (
     date_sent    TEXT,                      -- ISO-8601 or empty
     body_preview TEXT,                      -- first N chars of plain-text body
     file_mtime   REAL    NOT NULL,          -- os.stat().st_mtime for change detection
-    indexed_at   TEXT    NOT NULL DEFAULT (datetime('now'))
+    indexed_at   TEXT    NOT NULL DEFAULT (datetime('now')),
+    flag_status  INTEGER                    -- MAPI PidTagFlagStatus; see _COLUMNS
 );
 
 CREATE INDEX IF NOT EXISTS idx_emails_folder  ON emails(folder_path);
@@ -84,6 +88,37 @@ CREATE INDEX IF NOT EXISTS idx_folders_path ON folders(folder_path);
 """
 
 
+# Columns added to `emails` after the table shipped. The DDL above only runs
+# under CREATE TABLE IF NOT EXISTS, so on an existing database it is a no-op and
+# a new column would never appear -- every install here predates these, so they
+# have to be ALTERed in explicitly. Keep the two in sync: a column listed here
+# must also be in the CREATE TABLE, so a fresh database and a migrated one end
+# up identical.
+_COLUMNS: dict[str, str] = {
+    # MAPI PidTagFlagStatus (0x1090): 2 = flagged for follow-up, 1 = completed,
+    # 0 = not flagged. Deliberately nullable with no default -- NULL means "this
+    # row was indexed before the scanner read the property", which is a
+    # different fact from 0, "read, and not flagged". Rows indexed before this
+    # build keep NULL until their file changes and is re-read.
+    "flag_status": "INTEGER",
+}
+
+
+def _add_missing_columns(conn: sqlite3.Connection) -> list[str]:
+    """ALTER IN the `_COLUMNS` an existing `emails` table is missing.
+
+    Returns the columns actually added, so a caller can log a real migration.
+    Idempotent: a second run finds nothing to do.
+    """
+    have = {row["name"] for row in conn.execute("PRAGMA table_info(emails)")}
+    added = []
+    for name, decl in _COLUMNS.items():
+        if name not in have:
+            conn.execute(f"ALTER TABLE emails ADD COLUMN {name} {decl}")
+            added.append(name)
+    return added
+
+
 def get_connection(db_path: str | Path) -> sqlite3.Connection:
     """
     Open a SQLite connection with sensible defaults.
@@ -98,9 +133,13 @@ def get_connection(db_path: str | Path) -> sqlite3.Connection:
 
 
 def init_db(db_path: str | Path) -> sqlite3.Connection:
-    """Create all tables/indexes/triggers if they don't exist yet."""
+    """Create all tables/indexes/triggers if they don't exist yet, then bring an
+    older `emails` table up to the current column set."""
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = get_connection(db_path)
     conn.executescript(_DDL)
+    added = _add_missing_columns(conn)
+    if added:
+        logger.info("Added column(s) to emails: %s", ", ".join(added))
     conn.commit()
     return conn

--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -29,6 +29,10 @@ class EmailRecord:
     date_sent: str = ""
     body_preview: str = ""
     file_mtime: float = 0.0
+    # MAPI PidTagFlagStatus: 2 = flagged for follow-up, 0 = not flagged. The
+    # scanner always supplies it, so 0 here means "read, unflagged" -- unlike a
+    # NULL in the column, which means "indexed before the scanner read it".
+    flag_status: int = 0
     id: int | None = None
 
 
@@ -82,8 +86,8 @@ class EmailRepository:
             """
             INSERT INTO emails
                 (file_path, folder_path, filename, subject, sender,
-                 recipients, date_sent, body_preview, file_mtime)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 recipients, date_sent, body_preview, file_mtime, flag_status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
                 subject      = excluded.subject,
                 sender       = excluded.sender,
@@ -91,12 +95,14 @@ class EmailRepository:
                 date_sent    = excluded.date_sent,
                 body_preview = excluded.body_preview,
                 file_mtime   = excluded.file_mtime,
+                flag_status  = excluded.flag_status,
                 indexed_at   = datetime('now')
             """,
             (
                 rec.file_path, rec.folder_path, rec.filename,
                 rec.subject, rec.sender, rec.recipients,
                 rec.date_sent, rec.body_preview, rec.file_mtime,
+                rec.flag_status,
             ),
         )
 

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -7,6 +7,10 @@ Design decisions:
 - Batch commits: writes to DB every `batch_size` records to balance memory
   usage vs. write overhead.
 - Errors in individual .msg files are logged and skipped; the scan continues.
+- Records Outlook's follow-up flag (`flag_status`) so downstream tools can turn
+  a flagged mail into a task. The flag is written into the .msg at archive time
+  by `SaveAs`, so flagging a message *after* it is archived changes nothing --
+  the file on disk is a snapshot. Flag first, then archive.
 - progress_callback(current, total, current_file) is called after each file
   so the UI can update a progress bar without polling.
 """
@@ -44,9 +48,25 @@ def _safe_str(value: object) -> str:
     return str(value).strip() if value else ""
 
 
+# MAPI PidTagFlagStatus, PT_LONG. The `0003` type suffix is part of the key and
+# a wrong one returns None rather than raising -- verified against .msg files
+# Outlook wrote with SaveAs: a flagged item reads 2, an unflagged item has no
+# 0x1090 property at all. So "absent" means unflagged, not "read failed".
+_PR_FLAG_STATUS = "10900003"
+FLAG_FOLLOWUP = 2
+
+
+def _flag_status(msg: object) -> int:
+    """The follow-up flag Outlook stored in the .msg, or 0 when there is none."""
+    try:
+        return int(msg.getPropertyVal(_PR_FLAG_STATUS) or 0)
+    except (AttributeError, TypeError, ValueError):
+        return 0
+
+
 def _extract_msg_metadata(
     file_path: str, body_preview_len: int
-) -> dict[str, str] | None:
+) -> dict[str, object] | None:
     """
     Open a .msg file and extract metadata.
     Returns None on any read error (error is logged).
@@ -74,6 +94,7 @@ def _extract_msg_metadata(
                 "recipients": recipients,
                 "body_preview": body,
                 "date_sent": date_sent,
+                "flag_status": _flag_status(msg),
             }
 
     except (InvalidFileFormatError, UnrecognizedMSGTypeError) as exc:

--- a/tests/test_flag_status.py
+++ b/tests/test_flag_status.py
@@ -1,0 +1,161 @@
+"""Tests for the Outlook follow-up flag the scanner records (issue #51).
+
+A sister tool (task-os) turns a flagged, archived mail into a task by reading
+``emails.flag_status`` from this index, read-only. Three things have to hold for
+that to work, and each has its own failure mode:
+
+- the column exists on an **existing** database, not only a fresh one --
+  ``init_db`` runs ``CREATE TABLE IF NOT EXISTS``, so a DDL edit alone is a
+  silent no-op against the ~18k-row index this repo actually has;
+- the property read distinguishes *unflagged* from *unreadable* -- MAPI omits
+  0x1090 entirely on an unflagged message, so "absent" is a real answer;
+- a pre-existing row reads NULL, not 0. NULL means "indexed before the scanner
+  read the property"; 0 means "read, and not flagged". Folding the first into
+  the second would assert a fact nobody established.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from email_archiver.database.models import _COLUMNS, init_db
+from email_archiver.database.repository import EmailRecord, EmailRepository
+from email_archiver.scanner.scanner import FLAG_FOLLOWUP, _flag_status
+
+# The `emails` table as it shipped before this change, used to prove the
+# migration on a database that predates the column.
+_OLD_DDL = """
+CREATE TABLE emails (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path    TEXT    UNIQUE NOT NULL,
+    folder_path  TEXT    NOT NULL,
+    filename     TEXT    NOT NULL,
+    subject      TEXT,
+    sender       TEXT,
+    recipients   TEXT,
+    date_sent    TEXT,
+    body_preview TEXT,
+    file_mtime   REAL    NOT NULL,
+    indexed_at   TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
+
+class _FakeMsg:
+    """Stands in for ``extract_msg.Message``: only ``getPropertyVal`` is used."""
+
+    def __init__(self, props: dict[str, object]) -> None:
+        self._props = props
+
+    def getPropertyVal(self, key: str):  # noqa: N802 - extract_msg's spelling
+        return self._props.get(key)
+
+
+def _columns(conn: sqlite3.Connection) -> set[str]:
+    return {r["name"] for r in conn.execute("PRAGMA table_info(emails)")}
+
+
+# ------------------------------------------------------- the property read ---
+
+def test_a_flagged_message_reads_as_flagged():
+    assert _flag_status(_FakeMsg({"10900003": 2})) == FLAG_FOLLOWUP
+
+
+def test_an_absent_property_is_unflagged_not_an_error():
+    # MAPI writes 0x1090 only when a flag is set, so a plain message has no
+    # such property at all. That is an answer, not a failure.
+    assert _flag_status(_FakeMsg({})) == 0
+
+
+def test_a_property_of_the_wrong_shape_does_not_raise():
+    # A .msg that stores something unexpected must not abort the whole scan.
+    for value in ("", "not-a-number", None, object()):
+        assert _flag_status(_FakeMsg({"10900003": value})) == 0
+
+
+def test_the_read_does_not_swallow_a_completed_flag():
+    # 1 = flagged-then-completed. It is not 2, so it is not follow-up work, but
+    # it must be carried through as itself rather than flattened to 0.
+    assert _flag_status(_FakeMsg({"10900003": 1})) == 1
+
+
+# ------------------------------------------------------------ the migration --
+
+def test_a_fresh_database_has_the_column(tmp_path):
+    conn = init_db(str(tmp_path / "emails.db"))
+    assert "flag_status" in _columns(conn)
+
+
+def test_an_existing_database_gains_the_column_without_losing_rows(tmp_path):
+    """The case a DDL edit alone would silently miss."""
+    path = str(tmp_path / "emails.db")
+    old = sqlite3.connect(path)
+    old.executescript(_OLD_DDL)
+    old.execute(
+        "INSERT INTO emails (file_path, folder_path, filename, file_mtime)"
+        " VALUES ('a.msg', 'C:/archive', 'a.msg', 1.0)"
+    )
+    old.commit()
+    old.close()
+
+    conn = init_db(path)
+
+    assert "flag_status" in _columns(conn)
+    row = conn.execute("SELECT * FROM emails WHERE file_path = 'a.msg'").fetchone()
+    assert row is not None, "the migration must not lose the existing row"
+    assert row["flag_status"] is None, (
+        "a row indexed before the property was read must stay NULL -- 0 would "
+        "claim it was read and found unflagged"
+    )
+
+
+def test_the_migration_is_idempotent(tmp_path):
+    path = str(tmp_path / "emails.db")
+    init_db(path).close()
+    # A duplicate-column error here would break every later scan.
+    conn = init_db(path)
+    assert "flag_status" in _columns(conn)
+
+
+def test_every_migrated_column_is_also_in_the_create_table(tmp_path):
+    """A fresh database and a migrated one must end up identical."""
+    fresh = _columns(init_db(str(tmp_path / "fresh.db")))
+    assert set(_COLUMNS) <= fresh
+
+
+# ------------------------------------------------------------ the round trip --
+
+def test_the_flag_survives_a_write_and_an_update(tmp_path):
+    conn = init_db(str(tmp_path / "emails.db"))
+    repo = EmailRepository(conn)
+    rec = EmailRecord(
+        file_path="a.msg", folder_path="C:/archive", filename="a.msg",
+        file_mtime=1.0, flag_status=FLAG_FOLLOWUP,
+    )
+    repo.upsert_email(rec)
+    conn.commit()
+
+    stored = conn.execute("SELECT flag_status FROM emails WHERE file_path='a.msg'")
+    assert stored.fetchone()["flag_status"] == FLAG_FOLLOWUP
+
+    # Re-archiving the same path with the flag cleared must update, not keep a
+    # stale 2 -- otherwise a task would be raised for mail no longer flagged.
+    repo.upsert_email(EmailRecord(
+        file_path="a.msg", folder_path="C:/archive", filename="a.msg",
+        file_mtime=2.0, flag_status=0,
+    ))
+    conn.commit()
+    stored = conn.execute("SELECT flag_status FROM emails WHERE file_path='a.msg'")
+    assert stored.fetchone()["flag_status"] == 0
+
+
+def test_an_unflagged_record_defaults_to_read_and_unflagged(tmp_path):
+    conn = init_db(str(tmp_path / "emails.db"))
+    EmailRepository(conn).upsert_email(EmailRecord(
+        file_path="a.msg", folder_path="C:/archive", filename="a.msg",
+        file_mtime=1.0,
+    ))
+    conn.commit()
+    row = conn.execute("SELECT flag_status FROM emails").fetchone()
+    assert row["flag_status"] == 0, (
+        "the scanner always reads the property, so a row it wrote is 0, not NULL"
+    )


### PR DESCRIPTION
## Summary

Records Outlook's follow-up flag on each indexed `.msg` as `emails.flag_status`, so a flagged mail can become a task without a second app: **flag in Outlook, archive as usual**, and task-os's poller — which reads this index strictly read-only — raises one Inbox task for it. This is the upstream half of `ferraroroberto/task-os#98`, whose capture service is already merged and live, currently reporting itself *not configured* and naming this exact gap.

The work itself is small: `archiver.py:286` already saves the file with `mail_item.SaveAs(path, olMSG)` **from the live Outlook item**, so the flag is inside the `.msg` at archive time, and the scanner already opens every file it indexes. One property read on a file already in hand.

Three decisions are worth a reviewer's attention.

**`init_db` now ALTERs in missing columns.** Without this the change would be a silent no-op on every existing install — the DDL only runs under `CREATE TABLE IF NOT EXISTS`, so the real 18,422-row index would never gain the column no matter how many times it ran. `_COLUMNS` is the list, and it is also in the `CREATE TABLE`, so a fresh database and a migrated one end up identical.

**`flag_status` is nullable with no default, deliberately.** `NULL` means *indexed before the scanner read the property*; `0` means *read, and not flagged*. Those are different facts and defaulting to `0` would assert one nobody established. Rows predating this build stay `NULL` until their file changes.

**No `flag_request` column.** `PidLidFlagRequest` (named `0x8530`) reads `None` even on an item whose `FlagRequest` was set to `"Follow up"` before `SaveAs`, and the literal text appears in no property of the saved file. A column that can never hold a value is worse than no column; task-os already degrades cleanly without it (`NULL AS flag_request`).

## Verifying the property id, rather than trusting it

Guessing a MAPI tag is how this silently returns `None` forever, so it was probed against files Outlook actually wrote:

- `getPropertyVal("10900003")` returns **2** on a flagged item and **`None`** on an unflagged one — the property is absent from the stream entirely, because MAPI writes it only when a flag is set. So the read treats absent as *unflagged*, not as a failure.
- **The type suffix genuinely matters and fails silently when wrong.** The control read of `PidTagSubject` as `0037001F` (PT_UNICODE) returned nothing on 50 real archived files — they store `0037001E`, PT_STRING8. Had the flag suffix been wrong the same way, every message would have read unflagged forever with nothing to show for it.
- **No mass-capture hazard.** The worry was that adding the column would let a re-index dump the backlog into someone's Inbox. A random sample of **600 of the 18,422** indexed files carries the property **0 times** — Outlook does not preserve the flag through filing. So no forced re-index path is needed, and the incremental mtime skip costs nothing.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m pytest tests/` — **62 passed** (10 new).
- [x] The migration test proven to fail against pre-fix code: with the `ALTER` disabled, `test_an_existing_database_gains_the_column_without_losing_rows` fails on the missing column while the other 9 still pass — it discriminates the defect rather than the change.
- [x] **Rehearsed on a copy of the real 18,422-row database** (via the sqlite backup API, so the live file was only ever read): column added in 0.07 s, no row lost, every pre-existing row `NULL`, and a second `init_db` is a clean no-op.
- [x] **End-to-end across both repos against that copy:** task-os's `FlaggedEmailIndex` flips from *not configured* to `(True, None)`, finds **0** flagged rows on the untouched backlog, and finds exactly **1** after a single row is marked — with the ref folded to `{onedrive}/…`, which is the form the drawer's opener chip needs.
- [x] Byte-compile clean.

Docs: README gains the column, the *flag first, then archive* limit (an archived `.msg` is a snapshot — flagging it afterwards changes nothing on disk), and the `NULL` vs `0` distinction. `docs/architecture.mmd` and `.fleet.toml` updated in the same PR per their anti-staleness contracts.

Closes #51

https://claude.ai/code/session_0146cv8fPQLyDp7CroStkbtY
