### PR TITLE
feat: headless batch plan/apply/revert over the whole Inbox

### DIFF
--- a/.fleet.toml
+++ b/.fleet.toml
@@ -4,5 +4,5 @@
 # description, exposed services). Schema: fleet-config/architecture/README.md.
 layer       = "working-pipe"
 icon        = "📧"
-description = "Outlook → OneDrive archive. Its SQLite index records the follow-up flag, which task-os polls read-only to raise a task per flagged mail."
+description = "Outlook → OneDrive archive. Its SQLite index records the follow-up flag, which task-os polls read-only to raise a task per flagged mail; main_batch.py exposes headless plan/apply/revert over the whole Inbox with JSON I/O for the same consumer."
 tag         = ["→", "OneDrive"]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ archiver/
 │
 ├── email_archiver/              ← Main package
 │   ├── config.py                ← YAML loader, path resolution, logging setup
-│   ├── text.py                  ← Shared subject normalisation (Re:/Fwd: stripping)
+│   ├── text.py                  ← Shared subject + Message-ID normalisation
+│   ├── batch.py                 ← Headless plan/apply/revert orchestration (no COM, no tkinter)
 │   ├── explorer.py              ← Foremost open Explorer window → folder path
 │   │
 │   ├── database/
@@ -128,13 +129,14 @@ archiver/
 │       ├── app.py              ← ArchiveDialog, ScanWindow, LauncherApp
 │       └── dialogs.py          ← Native folder-picker wrapper
 │
-├── tests/                       ← pytest suite (filename fitting, sequencing, date-prefix toggle, Explorer picker, is_running regression)
+├── tests/                       ← pytest suite (filename fitting, sequencing, date-prefix toggle, Explorer picker, is_running regression, Message-ID, batch verbs)
 ├── docs/
 │   └── architecture.mmd         ← Hand-authored Mermaid diagram of internal structure
 │
 ├── main_archive.py              ← Stream Deck entry: Archive Email
 ├── main_scan.py                 ← Stream Deck entry: Scan Archive
 ├── main_ui.py                   ← Full launcher (both buttons)
+├── main_batch.py                ← Headless entry: plan / apply / revert the whole Inbox (JSON)
 ├── launch_archive.bat           ← Runs pythonw main_archive.py (no console)
 ├── launch_scan.bat              ← Runs pythonw main_scan.py (no console)
 └── requirements.txt
@@ -238,13 +240,68 @@ The `.bat` files use `pythonw` so no console window flashes on screen.
 
 ## Verification
 
-The project ships a pytest suite (`tests/`) covering the filename fitter, sequencing, the date-prefix toggle, the Explorer picker, and the `is_running()` regression. Run it before declaring any change done:
+The project ships a pytest suite (`tests/`) covering the filename fitter, sequencing, the date-prefix toggle, the Explorer picker, the `is_running()` regression, the Message-ID column and its migration, and every batch verb end to end against a fake Outlook client. Run it before declaring any change done:
 
 ```powershell
 & .\.venv\Scripts\python.exe -m pytest tests/
 ```
 
 `pytest` is a dev-only dependency — see `requirements.txt`.
+
+---
+
+## Batch mode (headless)
+
+`main_batch.py` is the archiver's headless face: three verbs that file the **whole Inbox** in one run instead of one selected mail at a time, each printing exactly one JSON document on stdout. It exists so another local app can drive the archiver as a subprocess — the archiver stays the sole owner of Outlook COM, the suggestion engine and the naming rules, and the caller only decides *which folder* each mail goes to.
+
+```powershell
+& .\.venv\Scripts\python.exe main_batch.py plan --candidates 5 > plan.json
+& .\.venv\Scripts\python.exe main_batch.py apply --decisions decisions.json
+& .\.venv\Scripts\python.exe main_batch.py revert --items revert.json
+```
+
+| Verb | Reads | Does |
+|---|---|---|
+| `plan` | nothing | Starts Outlook if it is closed, enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10). Read-only. |
+| `apply` | `[{message_id, folder_path, date_prefix}]` | Archives each mail into `folder_path`, then moves it to the Outlook `Archive` folder and tags it with the category. |
+| `revert` | `[{message_id, files}]` | Deletes exactly the listed files, removes the category and moves the mail back to the Inbox. |
+
+An `apply` result can be handed straight back to `revert` — the object with its `results` list is accepted as-is, no reshaping needed.
+
+### Identity: the Message-ID, not the EntryID
+
+Outlook rewrites a mail's `EntryID` when it is moved between folders, which is exactly what `apply` does to every mail it files. So the identity that ties the three verbs together is the **Internet Message-ID** (MAPI `PR_INTERNET_MESSAGE_ID`), stored without its angle brackets. The scanner records it for every `.msg` it indexes, which is what lets `plan` mark a mail as `already_archived` instead of offering to file it a second time. A mail carrying no Message-ID (rare — drafts, some system mail) is reported under `skipped` with `reason: "no_message_id"` and left alone, never guessed at.
+
+### Exit codes and error handling
+
+| Exit | Meaning |
+|---|---|
+| `0` | The run completed and stdout carries its document. Individual mails may still have failed — each result has its own `error` with a `code`. One failing mail never aborts the run. |
+| `2` | The run could not start. stdout carries `{"error": {"code", "message"}}` instead of results; the code is one of `config_missing`, `bad_input`, `outlook_unavailable`, `com_unavailable`. |
+
+Per-mail `error.code` values: `bad_decision` (the entry had no `message_id` or `folder_path`), `not_in_inbox`, `not_in_archive_folder`, `archive_failed`, `move_failed`.
+
+`apply` fills in a result's `files` **before** it moves the mail, so a mail that was written to disk but failed to move is still fully revertible — that is why a result can carry `ok: false` and a non-empty `files` at the same time.
+
+Every document carries `schema_version`, so a consumer can refuse a shape it does not understand rather than read a field that silently moved.
+
+### Safety
+
+- `revert` deletes **only** the files it is given, and only those that resolve inside `archive.root_paths`. Anything else is refused per file with a reason (`outside_archive_roots`, `unresolvable_path`) and left on disk.
+- A file already gone is reported as `missing`, not as an error — running a revert twice is not a failure to explain.
+- Outlook closed at `plan` time is **started** (the registered `outlook.exe`, visible, exactly as your own shortcut would) and waited for, bounded by `--start-timeout` (60 s by default). A still-unreachable Outlook is a loud exit 2, never an empty Inbox nobody read.
+- Batch mode is meant to be spawned with a timeout. A COM modal — the address-book security prompt, a profile chooser — then blocks *this* process, which the caller can kill, and never the caller.
+- The `date_prefix` flag is per mail and comes from the caller. Batch mode deliberately does **not** read the global `naming.date_prefix` toggle, because the right form depends on the destination folder.
+
+### Configuration
+
+```yaml
+outlook:
+  archive_folder: "Archive"           # created under the mailbox root if missing
+  category: "Archived by task-os"     # stamped by apply, removed by revert
+```
+
+Both keys are optional and fall back to the values above. The folder is matched case-insensitively so a mailbox that already has one is used rather than duplicated.
 
 ---
 
@@ -288,7 +345,8 @@ CREATE TABLE emails (
     body_preview TEXT,                   -- first 500 chars of plain text
     file_mtime   REAL NOT NULL,          -- for incremental scan (os.stat)
     indexed_at   TEXT NOT NULL DEFAULT (datetime('now')),
-    flag_status  INTEGER                  -- Outlook follow-up flag; see below
+    flag_status  INTEGER,                 -- Outlook follow-up flag; see below
+    message_id   TEXT                     -- Internet Message-ID; see below
 );
 
 -- FTS5 full-text index (kept in sync via triggers)
@@ -320,6 +378,13 @@ Two things about it are easy to get wrong:
 - **`NULL` is not `0`.** A row indexed before this column existed reads `NULL`, meaning *the property was never read* — a different fact from `0`, *read, and not flagged*. Existing rows keep `NULL` until their file changes and is re-indexed. That is deliberate and costs nothing: Outlook does not preserve the flag through filing, so an already-archived backlog carries no flags to find (a random sample of 600 of ~18k archived files found none).
 
 The column is added to an existing database automatically on the next run — `init_db` ALTERs in any column the `emails` table is missing, because its `CREATE TABLE IF NOT EXISTS` is a no-op once the table exists.
+
+### The Internet Message-ID (`message_id`)
+
+`message_id` records the mail's `Message-ID` header (MAPI `PR_INTERNET_MESSAGE_ID`, `0x1035001F`) read back out of the archived `.msg`, stored **without** its angle brackets so both sides of the app spell it the same way. It exists for [batch mode](#batch-mode-headless): it is the only identity that survives a mail being moved between Outlook folders, so it is what lets `plan` recognise a mail that is already filed and what pairs a `revert` with the files written for it.
+
+- **`NULL` is not `""`.** A row indexed before this column existed reads `NULL`, *the header was never read*; a `.msg` that genuinely carries no `Message-ID` reads `""`. Neither ever matches a lookup — two mails with no Message-ID are not the same mail.
+- Added to an existing database the same way `flag_status` was, plus an index on the column created **after** the ALTER — declaring it alongside the `CREATE TABLE` would run it against a column an existing database does not have yet and take the whole scan down with it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Outlook rewrites a mail's `EntryID` when it is moved between folders, which is e
 | `0` | The run completed and stdout carries its document. Individual mails may still have failed — each result has its own `error` with a `code`. One failing mail never aborts the run. |
 | `2` | The run could not start. stdout carries `{"error": {"code", "message"}}` instead of results; the code is one of `config_missing`, `bad_input`, `outlook_unavailable`, `com_unavailable`. |
 
-Per-mail `error.code` values: `bad_decision` (the entry had no `message_id` or `folder_path`), `not_in_inbox`, `not_in_archive_folder`, `archive_failed`, `move_failed`.
+Per-mail `error.code` values: `bad_decision` (the entry had no `message_id` or `folder_path`), `not_in_inbox`, `not_in_archive_folder`, `archive_failed`, `move_failed`, `category_failed`. The last two are deliberately distinct: after a `move_failed` the mail is still in the Inbox, after a `category_failed` it is already filed and only *looks* untouched in Outlook.
 
 `apply` fills in a result's `files` **before** it moves the mail, so a mail that was written to disk but failed to move is still fully revertible — that is why a result can carry `ok: false` and a non-empty `files` at the same time.
 
@@ -385,6 +385,7 @@ The column is added to an existing database automatically on the next run — `i
 
 - **`NULL` is not `""`.** A row indexed before this column existed reads `NULL`, *the header was never read*; a `.msg` that genuinely carries no `Message-ID` reads `""`. Neither ever matches a lookup — two mails with no Message-ID are not the same mail.
 - Added to an existing database the same way `flag_status` was, plus an index on the column created **after** the ALTER — declaring it alongside the `CREATE TABLE` would run it against a column an existing database does not have yet and take the whole scan down with it.
+- **The existing backlog is not backfilled.** Scanning is incremental on `mtime`, so a `.msg` indexed before this column existed is skipped and keeps its `NULL` — its Message-ID is in the file, but nothing has read it. Everything archived from now on is indexed with its id on the next scan (a new file is never skipped), so `plan`'s already-archived detection is complete for the batch workflow's own loop and blind only to mail filed before it. To cover the backlog too, force a full re-read by deleting `data/emails.db` and re-scanning — the same cost as a first scan.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Outlook rewrites a mail's `EntryID` when it is moved between folders, which is e
 | Exit | Meaning |
 |---|---|
 | `0` | The run completed and stdout carries its document. Individual mails may still have failed — each result has its own `error` with a `code`. One failing mail never aborts the run. |
-| `2` | The run could not start. stdout carries `{"error": {"code", "message"}}` instead of results; the code is one of `config_missing`, `bad_input`, `outlook_unavailable`, `com_unavailable`. |
+| `2` | The run could not start. stdout carries `{"error": {"code", "message"}}` instead of results; the code is one of `config_missing` (no config, **or** one that could not be loaded — a malformed `config.yaml` lands here too, with the parser error in `message`), `bad_input`, `outlook_unavailable`, `com_unavailable`. |
 
 Per-mail `error.code` values: `bad_decision` (the entry had no `message_id` or `folder_path`), `not_in_inbox`, `not_in_archive_folder`, `archive_failed`, `move_failed`, `category_failed`. The last two are deliberately distinct: after a `move_failed` the mail is still in the Inbox, after a `category_failed` it is already filed and only *looks* untouched in Outlook.
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -21,6 +21,14 @@ naming:
   # and undated files still gets the correct next number.
   date_prefix: false
 
+outlook:
+  # Batch mode only (main_batch.py). After `apply` has written a mail to disk
+  # it moves the mail out of the Inbox into this folder, looked up by name
+  # directly under the mailbox root and created if it does not exist, and
+  # stamps it with the category below. `revert` reverses both.
+  archive_folder: "Archive"
+  category: "Archived by task-os"
+
 database:
   # Path relative to the project root or absolute
   path: "data/emails.db"

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -13,14 +13,16 @@ flowchart TB
     MAINSCAN["main_scan.py\nheadless --no-ui, or opens ScanWindow"]
     MAINARCHIVE["main_archive.py\nopens ArchiveDialog directly"]
     MAINUI["main_ui.py\nopens LauncherApp (both buttons)"]
+    MAINBATCH["main_batch.py\nheadless plan / apply / revert,\none JSON document on stdout"]
   end
 
-  CONFIG["email_archiver/config.py\nload_config · get_archive_roots ·\nget_max_path_length · setup_logging"]
-  TEXT["email_archiver/text.py\nclean_subject — shared Re:/Fwd: stripping,\nused by both the scanner and the Outlook client"]
+  CONFIG["email_archiver/config.py\nload_config · get_archive_roots ·\nget_max_path_length · get_date_prefix_enabled ·\nget_outlook_archive_folder · get_outlook_category ·\nsetup_logging"]
+  TEXT["email_archiver/text.py\nclean_subject — shared Re:/Fwd: stripping ·\nnormalize_message_id — one spelling of the\nMessage-ID for the scanner and the Outlook client"]
 
   MAINSCAN --> CONFIG
   MAINARCHIVE --> CONFIG
   MAINUI --> CONFIG
+  MAINBATCH --> CONFIG
 
   subgraph ui["email_archiver/ui/"]
     LAUNCHER["app.py: LauncherApp"]
@@ -70,3 +72,15 @@ flowchart TB
   ARCHIVEDIALOG -->|user confirms folder + date-prefix checkbox| ARCHIVER
   ARCHIVER -->|SaveAs / SaveAsFile via| OUTLOOKCOM
   ARCHIVER -->|writes .msg + attachments| ONEDRIVE
+
+  subgraph batchflow["Batch mode data flow (headless, spawned by another app)"]
+    BATCH["batch.py\nplan · apply · revert —\npure orchestration, no COM, no tkinter.\nIdentity is the Internet Message-ID,\nnot EntryID (which a Move rewrites)"]
+  end
+  CALLER["another local app (task-os)\nspawns the process with a timeout,\nreads one JSON document"] -->|subprocess| MAINBATCH
+  MAINBATCH --> BATCH
+  BATCH -->|ensure_running · iter_inbox · find_by_message_id · move_to · set_category| OUTLOOK
+  OUTLOOK -->|starts if closed, polls GetActiveObject| OUTLOOKCOM
+  BATCH -->|plan: rank folders per mail| SUGGESTER
+  BATCH -->|plan: already archived?| REPO
+  BATCH -->|apply: per-mail date_prefix| ARCHIVER
+  BATCH -->|revert: delete only inside archive.root_paths| ONEDRIVE

--- a/email_archiver/batch.py
+++ b/email_archiver/batch.py
@@ -70,6 +70,11 @@ ERROR_NOT_IN_ARCHIVE = "not_in_archive_folder"  # revert cannot find it back
 ERROR_BAD_DECISION = "bad_decision"             # caller sent an unusable entry
 ERROR_ARCHIVE_FAILED = "archive_failed"         # disk write / Outlook SaveAs
 ERROR_MOVE_FAILED = "move_failed"               # files are on disk, mail is not
+# The move landed and only the tag did not. Its own code because the two are
+# genuinely different states to recover from: after a move_failed the mail is
+# still in the Inbox, after a category_failed it is already filed and only
+# looks untouched in Outlook.
+ERROR_CATEGORY_FAILED = "category_failed"
 
 # Per-file outcomes in a revert result.
 REFUSED_OUTSIDE_ROOTS = "outside_archive_roots"
@@ -356,13 +361,27 @@ def apply(
             moved = client.move_to(item, archive_folder)
             result["moved"] = True
             result["entry_id"] = client.entry_id(moved)
-            client.set_category(moved, category)
-            result["categorized"] = True
         except Exception as exc:
             logger.exception("Moving %s to %r failed", message_id, archive_folder)
             result["error"] = {
                 "code": ERROR_MOVE_FAILED,
                 "message": f"{type(exc).__name__}: {exc}",
+            }
+            results.append(result)
+            continue
+
+        # Tagged in its own step: a category that would not stick is a
+        # different state from a move that did not happen, and the caller
+        # recovers from the two differently.
+        try:
+            client.set_category(moved, category)
+            result["categorized"] = True
+        except Exception as exc:
+            logger.exception("Tagging %s with %r failed", message_id, category)
+            result["error"] = {
+                "code": ERROR_CATEGORY_FAILED,
+                "message": f"the mail was filed and moved, but not tagged: "
+                           f"{type(exc).__name__}: {exc}",
             }
             results.append(result)
             continue

--- a/email_archiver/batch.py
+++ b/email_archiver/batch.py
@@ -1,0 +1,495 @@
+"""
+Headless batch mode: plan / apply / revert the whole Inbox with JSON I/O.
+
+This module is what ``main_batch.py`` runs and what the tests exercise. It is
+pure orchestration over :class:`~email_archiver.outlook.client.OutlookClient`,
+:class:`~email_archiver.engine.suggester.SuggestionEngine`,
+:class:`~email_archiver.archiver.archiver.EmailArchiver` and
+:class:`~email_archiver.database.repository.EmailRepository` — no COM, no
+tkinter — so a fake client drives every verb end to end in a unit test.
+
+Design decisions:
+
+- **Identity is the Internet Message-ID, never EntryID.** Outlook rewrites
+  ``EntryID`` when a mail moves between folders, which is exactly what ``apply``
+  does to every mail it touches; the Message-ID survives. A mail carrying no
+  Message-ID (rare — drafts, some system mail) is *reported and skipped*, never
+  guessed at.
+- **The archiver stays the sole owner of the naming rules.** Batch mode chooses
+  nothing about filenames; it passes the caller's per-mail ``date_prefix``
+  decision into ``EmailArchiver`` and lets it do what the dialog does.
+- **One failing mail never aborts the run.** Every verb returns a document with
+  a per-mail result carrying its own ``error``, and the process still exits 0.
+  A non-zero exit means the run could not *start* at all (see ``main_batch.py``).
+- **``files`` is filled in before the move**, so a mail that was written to disk
+  but failed to move is still fully revertible from the ``apply`` output. That
+  is why an entry can carry ``ok: false`` and a non-empty ``files`` at once.
+- **``revert`` deletes only what it is given, and only inside the archive
+  roots.** Anything resolving outside ``archive.root_paths`` is refused per
+  file with a reason rather than deleted, so a malformed or hostile items file
+  cannot reach the rest of the disk.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from email_archiver.archiver.archiver import EmailArchiver
+from email_archiver.config import (
+    get_archive_roots,
+    get_outlook_archive_folder,
+    get_outlook_category,
+)
+from email_archiver.database.models import init_db
+from email_archiver.database.repository import EmailRepository
+from email_archiver.engine.suggester import SuggestionEngine
+from email_archiver.outlook.client import EmailData
+from email_archiver.text import normalize_message_id
+
+logger = logging.getLogger(__name__)
+
+# Bumped when the shape of a document below changes incompatibly, so a consumer
+# spawning this process can refuse a version it does not understand instead of
+# reading a field that silently moved.
+SCHEMA_VERSION = 1
+
+# Default number of ranked folder candidates `plan` reports per mail. Larger
+# than the dialog's three: the caller re-ranks (an LLM, in task-os's case) and
+# needs more than the engine's own top pick to choose from.
+DEFAULT_CANDIDATES = 10
+
+# Why a mail in the Inbox got no plan entry.
+SKIP_NO_MESSAGE_ID = "no_message_id"
+
+# `error.code` values, and the reason each one is worth telling apart.
+ERROR_NOT_IN_INBOX = "not_in_inbox"            # already moved, or never there
+ERROR_NOT_IN_ARCHIVE = "not_in_archive_folder"  # revert cannot find it back
+ERROR_BAD_DECISION = "bad_decision"             # caller sent an unusable entry
+ERROR_ARCHIVE_FAILED = "archive_failed"         # disk write / Outlook SaveAs
+ERROR_MOVE_FAILED = "move_failed"               # files are on disk, mail is not
+
+# Per-file outcomes in a revert result.
+REFUSED_OUTSIDE_ROOTS = "outside_archive_roots"
+REFUSED_UNRESOLVABLE = "unresolvable_path"
+
+
+# ---------------------------------------------------------------- helpers ---
+
+def _now_iso() -> str:
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def _iso_or_empty(value: datetime | None) -> str:
+    return value.isoformat() if value is not None else ""
+
+
+def _engine_for(cfg: dict[str, Any], candidates: int) -> SuggestionEngine:
+    """A suggestion engine capped at ``candidates`` instead of the config's 3.
+
+    The cap is the only knob batch mode changes, and it changes it on a copy —
+    the loaded config is shared process-wide and the dialog must keep seeing
+    its own ``suggestion.max_suggestions``.
+    """
+    tuned = dict(cfg)
+    tuned["suggestion"] = {**(cfg.get("suggestion") or {}), "max_suggestions": candidates}
+    return SuggestionEngine(tuned)
+
+
+def _candidate_dict(suggestion: Any) -> dict[str, Any]:
+    return {
+        "folder_path": suggestion.folder_path,
+        "display_name": suggestion.display_name,
+        "score": round(suggestion.score, 4),
+        "match_count": suggestion.match_count,
+        "sample_subjects": list(suggestion.sample_subjects),
+    }
+
+
+def _mail_dict(mail: Any) -> dict[str, Any]:
+    """The fields of a live mail every verb reports, in one shape."""
+    return {
+        "message_id": mail.message_id,
+        "entry_id": mail.entry_id,
+        "subject": mail.subject,
+        "sender": mail.sender,
+        "recipients": mail.recipients,
+        "date_sent": _iso_or_empty(mail.date_sent),
+        "body_preview": mail.body_preview,
+        "attachment_count": mail.attachment_count,
+        "flag_status": mail.flag_status,
+    }
+
+
+def _is_within(child: Path, root: Path) -> bool:
+    """Whether ``child`` is ``root`` or lives underneath it.
+
+    Compared through ``os.path.normcase`` rather than
+    ``Path.is_relative_to`` alone: on Windows the two paths routinely differ in
+    case (the config spells a root one way, ``resolve()`` another) and a
+    case-sensitive comparison would refuse a file that is genuinely inside the
+    archive. The trailing separator is what stops ``C:\\Archive`` from matching
+    ``C:\\ArchiveOther``.
+    """
+    child_s = os.path.normcase(str(child))
+    root_s = os.path.normcase(str(root))
+    if child_s == root_s:
+        return True
+    return child_s.startswith(root_s.rstrip("\\/") + os.sep)
+
+
+def _resolve_under_roots(
+    raw_path: str, roots: list[Path]
+) -> tuple[Path | None, str | None]:
+    """Resolve a path and require it to sit under one of the archive roots.
+
+    Returns ``(path, None)`` when it does, ``(None, reason)`` when it does not.
+    The refusal is deliberately not an exception: ``revert`` reports it per file
+    and carries on with the rest of the bundle.
+    """
+    try:
+        resolved = Path(raw_path).resolve()
+    except (OSError, ValueError):
+        return None, REFUSED_UNRESOLVABLE
+    for root in roots:
+        if _is_within(resolved, root):
+            return resolved, None
+    return None, REFUSED_OUTSIDE_ROOTS
+
+
+def _archive_roots(cfg: dict[str, Any]) -> list[Path]:
+    resolved: list[Path] = []
+    for raw in get_archive_roots(cfg):
+        try:
+            resolved.append(Path(raw).resolve())
+        except (OSError, ValueError):
+            logger.warning("Ignoring unresolvable archive root: %r", raw)
+    return resolved
+
+
+def _envelope(verb: str, cfg: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "verb": verb,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _now_iso(),
+        "archive_folder": get_outlook_archive_folder(cfg),
+        "category": get_outlook_category(cfg),
+    }
+
+
+def error_document(verb: str, code: str, message: str) -> dict[str, Any]:
+    """The document printed when the run could not start at all.
+
+    Deliberately the same envelope shape minus the results, so a consumer
+    parses one JSON document either way and branches on ``"error" in doc``
+    rather than on the exit code alone.
+    """
+    return {
+        "verb": verb,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _now_iso(),
+        "error": {"code": code, "message": message},
+    }
+
+
+# ------------------------------------------------------------------- plan ---
+
+def plan(
+    client: Any,
+    cfg: dict[str, Any],
+    *,
+    candidates: int = DEFAULT_CANDIDATES,
+) -> dict[str, Any]:
+    """Enumerate the Inbox and rank archive folders for every mail in it.
+
+    Every Inbox mail is offered: nothing is filtered on age, sender or size.
+    A mail whose Message-ID is already in the index is reported with
+    ``already_archived`` set to the file it was archived as, and no candidates —
+    ranking a mail that is already filed would only invite filing it twice.
+    """
+    preview_len = int((cfg.get("scanning") or {}).get("body_preview_length", 500))
+    engine = _engine_for(cfg, candidates)
+
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+
+    mails: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    already = 0
+
+    try:
+        for mail in client.iter_inbox(preview_len):
+            if not mail.message_id:
+                skipped.append({
+                    "entry_id": mail.entry_id,
+                    "subject": mail.subject,
+                    "reason": SKIP_NO_MESSAGE_ID,
+                })
+                continue
+
+            entry = _mail_dict(mail)
+            archived_as = repo.find_path_by_message_id(mail.message_id)
+            entry["already_archived"] = archived_as
+            if archived_as:
+                already += 1
+                entry["candidates"] = []
+            else:
+                entry["candidates"] = [
+                    _candidate_dict(s)
+                    for s in engine.suggest(EmailData(
+                        subject=mail.subject,
+                        sender=mail.sender,
+                        recipients=mail.recipients,
+                        date_sent=mail.date_sent,
+                    ))
+                ]
+            mails.append(entry)
+    finally:
+        conn.close()
+
+    doc = _envelope("plan", cfg)
+    doc["counts"] = {
+        "inbox": len(mails) + len(skipped),
+        "planned": len(mails) - already,
+        "already_archived": already,
+        "skipped": len(skipped),
+    }
+    doc["mails"] = mails
+    doc["skipped"] = skipped
+    logger.info(
+        "Plan: %d mail(s) in the Inbox, %d already archived, %d skipped.",
+        doc["counts"]["inbox"], already, len(skipped),
+    )
+    return doc
+
+
+# ------------------------------------------------------------------ apply ---
+
+def _blank_apply_result(message_id: str, folder_path: str) -> dict[str, Any]:
+    return {
+        "message_id": message_id,
+        "folder_path": folder_path,
+        "ok": False,
+        "sequence_number": "",
+        "files": [],
+        "entry_id": "",
+        "moved": False,
+        "categorized": False,
+        "error": None,
+    }
+
+
+def apply(
+    client: Any,
+    cfg: dict[str, Any],
+    decisions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Archive each decided mail, move it out of the Inbox and tag it.
+
+    ``decisions`` is a list of ``{message_id, folder_path, date_prefix}``. The
+    ``date_prefix`` flag is per mail and comes from the caller — batch mode
+    never reads the global ``naming.date_prefix`` toggle, because the caller
+    infers the form the destination folder actually uses.
+
+    Whatever happens to one mail, the next is still attempted; the per-mail
+    ``error`` says what went wrong and ``files`` says what is already on disk.
+    """
+    archive_folder = get_outlook_archive_folder(cfg)
+    category = get_outlook_category(cfg)
+    results: list[dict[str, Any]] = []
+
+    for raw in decisions:
+        message_id = normalize_message_id(raw.get("message_id"))
+        folder_path = str(raw.get("folder_path") or "")
+        result = _blank_apply_result(message_id, folder_path)
+
+        if not message_id or not folder_path:
+            result["error"] = {
+                "code": ERROR_BAD_DECISION,
+                "message": "a decision needs both a message_id and a folder_path",
+            }
+            results.append(result)
+            continue
+
+        item = None
+        try:
+            item = client.find_by_message_id(message_id, None)
+        except Exception as exc:  # a COM failure on one lookup, not the run
+            result["error"] = {
+                "code": ERROR_NOT_IN_INBOX,
+                "message": f"Inbox lookup failed: {type(exc).__name__}: {exc}",
+            }
+            results.append(result)
+            continue
+
+        if item is None:
+            result["error"] = {
+                "code": ERROR_NOT_IN_INBOX,
+                "message": "no mail with this Message-ID is in the Inbox",
+            }
+            results.append(result)
+            continue
+
+        try:
+            mail = client.read_mail(item)
+            archiver = EmailArchiver(
+                cfg, date_prefix=bool(raw.get("date_prefix", False))
+            )
+            archived = archiver.archive(item, folder_path, mail.subject)
+        except Exception as exc:
+            logger.exception("Archiving %s failed", message_id)
+            result["error"] = {
+                "code": ERROR_ARCHIVE_FAILED,
+                "message": f"{type(exc).__name__}: {exc}",
+            }
+            results.append(result)
+            continue
+
+        result["sequence_number"] = archived.sequence_number
+        # Filled in before the move on purpose: if the move fails these files
+        # exist and the caller must be able to revert them.
+        result["files"] = [archived.email_path, *archived.attachment_paths]
+
+        try:
+            moved = client.move_to(item, archive_folder)
+            result["moved"] = True
+            result["entry_id"] = client.entry_id(moved)
+            client.set_category(moved, category)
+            result["categorized"] = True
+        except Exception as exc:
+            logger.exception("Moving %s to %r failed", message_id, archive_folder)
+            result["error"] = {
+                "code": ERROR_MOVE_FAILED,
+                "message": f"{type(exc).__name__}: {exc}",
+            }
+            results.append(result)
+            continue
+
+        result["ok"] = True
+        results.append(result)
+
+    doc = _envelope("apply", cfg)
+    applied = sum(1 for r in results if r["ok"])
+    doc["counts"] = {
+        "requested": len(results),
+        "applied": applied,
+        "failed": len(results) - applied,
+    }
+    doc["results"] = results
+    logger.info("Apply: %d of %d mail(s) filed.", applied, len(results))
+    return doc
+
+
+# ----------------------------------------------------------------- revert ---
+
+def _blank_revert_result(message_id: str) -> dict[str, Any]:
+    return {
+        "message_id": message_id,
+        "ok": False,
+        "deleted": [],
+        "missing": [],
+        "refused": [],
+        "file_errors": [],
+        "moved_back": False,
+        "category_removed": False,
+        "entry_id": "",
+        "error": None,
+    }
+
+
+def revert(
+    client: Any,
+    cfg: dict[str, Any],
+    items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Delete the listed archive files and put each mail back in the Inbox.
+
+    ``items`` is a list of ``{message_id, files}`` — normally straight from an
+    ``apply`` result. Only the listed files are touched, and only those that
+    resolve inside ``archive.root_paths``; anything else is refused with a
+    reason and left alone.
+
+    The four per-file buckets are deliberately distinct facts: ``deleted``
+    (gone now), ``missing`` (already gone — not an error, a revert run twice),
+    ``refused`` (policy said no) and ``file_errors`` (the delete was attempted
+    and the OS said no).
+    """
+    archive_folder = get_outlook_archive_folder(cfg)
+    category = get_outlook_category(cfg)
+    roots = _archive_roots(cfg)
+    results: list[dict[str, Any]] = []
+
+    for raw in items:
+        message_id = normalize_message_id(raw.get("message_id"))
+        result = _blank_revert_result(message_id)
+
+        for raw_path in raw.get("files") or []:
+            resolved, refusal = _resolve_under_roots(str(raw_path), roots)
+            if resolved is None:
+                result["refused"].append({"path": str(raw_path), "reason": refusal})
+                continue
+            try:
+                resolved.unlink()
+                result["deleted"].append(str(resolved))
+            except FileNotFoundError:
+                result["missing"].append(str(resolved))
+            except OSError as exc:
+                result["file_errors"].append(
+                    {"path": str(resolved), "message": f"{type(exc).__name__}: {exc}"}
+                )
+
+        if not message_id:
+            result["error"] = {
+                "code": ERROR_BAD_DECISION,
+                "message": "an item needs a message_id to move the mail back",
+            }
+            results.append(result)
+            continue
+
+        try:
+            item = client.find_by_message_id(message_id, archive_folder)
+        except Exception as exc:
+            item = None
+            logger.warning("Archive-folder lookup for %s failed: %s", message_id, exc)
+
+        if item is None:
+            result["error"] = {
+                "code": ERROR_NOT_IN_ARCHIVE,
+                "message": (
+                    f"no mail with this Message-ID is in {archive_folder!r}; "
+                    "the files listed above were still processed"
+                ),
+            }
+            results.append(result)
+            continue
+
+        try:
+            client.clear_category(item, category)
+            result["category_removed"] = True
+            moved = client.move_to(item, None)
+            result["moved_back"] = True
+            result["entry_id"] = client.entry_id(moved)
+        except Exception as exc:
+            logger.exception("Moving %s back to the Inbox failed", message_id)
+            result["error"] = {
+                "code": ERROR_MOVE_FAILED,
+                "message": f"{type(exc).__name__}: {exc}",
+            }
+            results.append(result)
+            continue
+
+        result["ok"] = not result["refused"] and not result["file_errors"]
+        results.append(result)
+
+    doc = _envelope("revert", cfg)
+    reverted = sum(1 for r in results if r["ok"])
+    doc["counts"] = {
+        "requested": len(results),
+        "reverted": reverted,
+        "failed": len(results) - reverted,
+    }
+    doc["results"] = results
+    logger.info("Revert: %d of %d mail(s) restored.", reverted, len(results))
+    return doc

--- a/email_archiver/config.py
+++ b/email_archiver/config.py
@@ -30,6 +30,13 @@ DEFAULT_MAX_PATH_LENGTH = 255
 # inside the .msg. See ``get_date_prefix_enabled``.
 DEFAULT_DATE_PREFIX_ENABLED = False
 
+# Where batch `apply` parks a mail once it is on disk, and the category it
+# stamps on it. The folder is looked up by name directly under the mailbox's
+# root and created if missing; the category makes it obvious in Outlook which
+# mails a batch run touched, and is what `revert` removes again.
+DEFAULT_ARCHIVE_FOLDER = "Archive"
+DEFAULT_ARCHIVED_CATEGORY = "Archived by task-os"
+
 _config: dict[str, Any] | None = None
 
 
@@ -100,6 +107,35 @@ def get_date_prefix_enabled(cfg: dict[str, Any]) -> bool:
     if value is None:
         return DEFAULT_DATE_PREFIX_ENABLED
     return bool(value)
+
+
+def get_outlook_archive_folder(cfg: dict[str, Any]) -> str:
+    """Return the Outlook folder batch ``apply`` moves a filed mail into.
+
+    Reads ``outlook.archive_folder``, falling back to
+    ``DEFAULT_ARCHIVE_FOLDER``. Like the other accessors here this is the one
+    place the key is read, so the batch layer never reaches into the config
+    dict itself. A blank value falls back rather than resolving to the mailbox
+    root, which would "move" the mail somewhere no one expects.
+    """
+    outlook_cfg = cfg.get("outlook") or {}
+    value = outlook_cfg.get("archive_folder")
+    return str(value).strip() if value and str(value).strip() else DEFAULT_ARCHIVE_FOLDER
+
+
+def get_outlook_category(cfg: dict[str, Any]) -> str:
+    """Return the Outlook category batch ``apply`` stamps on a filed mail.
+
+    Reads ``outlook.category``, falling back to
+    ``DEFAULT_ARCHIVED_CATEGORY``. ``revert`` removes exactly this category, so
+    changing it between an apply and its revert leaves the old one in place --
+    the files and the folder move still revert correctly.
+    """
+    outlook_cfg = cfg.get("outlook") or {}
+    value = outlook_cfg.get("category")
+    return (
+        str(value).strip() if value and str(value).strip() else DEFAULT_ARCHIVED_CATEGORY
+    )
 
 
 def _resolve_paths(cfg: dict[str, Any]) -> None:

--- a/email_archiver/database/models.py
+++ b/email_archiver/database/models.py
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS emails (
     body_preview TEXT,                      -- first N chars of plain-text body
     file_mtime   REAL    NOT NULL,          -- os.stat().st_mtime for change detection
     indexed_at   TEXT    NOT NULL DEFAULT (datetime('now')),
-    flag_status  INTEGER                    -- MAPI PidTagFlagStatus; see _COLUMNS
+    flag_status  INTEGER,                   -- MAPI PidTagFlagStatus; see _COLUMNS
+    message_id   TEXT                       -- Internet Message-ID; see _COLUMNS
 );
 
 CREATE INDEX IF NOT EXISTS idx_emails_folder  ON emails(folder_path);
@@ -101,7 +102,24 @@ _COLUMNS: dict[str, str] = {
     # different fact from 0, "read, and not flagged". Rows indexed before this
     # build keep NULL until their file changes and is re-read.
     "flag_status": "INTEGER",
+    # Internet Message-ID (MAPI PR_INTERNET_MESSAGE_ID, 0x1035001F), stored
+    # without its angle brackets -- see text.normalize_message_id. It is the
+    # only identity that survives a mail being moved between Outlook folders
+    # (EntryID does not), so the batch verbs use it to tell an Inbox mail that
+    # is already archived from one that is not, and to pair a revert with the
+    # files that were written for it. Nullable like flag_status: NULL means
+    # "indexed before the scanner read the header", not "this mail has none"
+    # (that is stored as an empty string).
+    "message_id": "TEXT",
 }
+
+# Indexes over columns that only exist after `_add_missing_columns` has run.
+# They cannot live in `_DDL`, which `init_db` executes *before* the migration:
+# on an existing database the index would be created against a column the table
+# does not have yet and the whole script would fail.
+_POST_MIGRATION_DDL = """
+CREATE INDEX IF NOT EXISTS idx_emails_message_id ON emails(message_id);
+"""
 
 
 def _add_missing_columns(conn: sqlite3.Connection) -> list[str]:
@@ -141,5 +159,6 @@ def init_db(db_path: str | Path) -> sqlite3.Connection:
     added = _add_missing_columns(conn)
     if added:
         logger.info("Added column(s) to emails: %s", ", ".join(added))
+    conn.executescript(_POST_MIGRATION_DDL)
     conn.commit()
     return conn

--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -33,6 +33,10 @@ class EmailRecord:
     # scanner always supplies it, so 0 here means "read, unflagged" -- unlike a
     # NULL in the column, which means "indexed before the scanner read it".
     flag_status: int = 0
+    # Internet Message-ID without angle brackets (see text.normalize_message_id).
+    # "" means the .msg carried no Message-ID header -- a real answer, and the
+    # reason a lookup by id never matches on the empty string.
+    message_id: str = ""
     id: int | None = None
 
 
@@ -86,8 +90,9 @@ class EmailRepository:
             """
             INSERT INTO emails
                 (file_path, folder_path, filename, subject, sender,
-                 recipients, date_sent, body_preview, file_mtime, flag_status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 recipients, date_sent, body_preview, file_mtime, flag_status,
+                 message_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
                 subject      = excluded.subject,
                 sender       = excluded.sender,
@@ -96,13 +101,14 @@ class EmailRepository:
                 body_preview = excluded.body_preview,
                 file_mtime   = excluded.file_mtime,
                 flag_status  = excluded.flag_status,
+                message_id   = excluded.message_id,
                 indexed_at   = datetime('now')
             """,
             (
                 rec.file_path, rec.folder_path, rec.filename,
                 rec.subject, rec.sender, rec.recipients,
                 rec.date_sent, rec.body_preview, rec.file_mtime,
-                rec.flag_status,
+                rec.flag_status, rec.message_id,
             ),
         )
 
@@ -157,6 +163,28 @@ class EmailRepository:
             "SELECT file_mtime FROM emails WHERE file_path = ?", (file_path,)
         ).fetchone()
         return row["file_mtime"] if row else None
+
+    def find_path_by_message_id(self, message_id: str) -> str | None:
+        """Return the archived ``.msg`` path for a Message-ID, or ``None``.
+
+        Used by the batch ``plan`` verb to mark an Inbox mail that has already
+        been filed. An empty ``message_id`` never matches: rows written before
+        the column existed read NULL and rows for a ``.msg`` carrying no
+        Message-ID header read ``""``, and neither is evidence that *this*
+        mail is the one already on disk.
+
+        Only the most recently indexed match is returned when the same mail was
+        filed into more than one folder -- the caller only needs proof that it
+        was archived at all.
+        """
+        if not message_id:
+            return None
+        row = self._conn.execute(
+            "SELECT file_path FROM emails WHERE message_id = ? "
+            "ORDER BY indexed_at DESC LIMIT 1",
+            (message_id,),
+        ).fetchone()
+        return row["file_path"] if row else None
 
     def count_emails(self) -> int:
         row = self._conn.execute("SELECT COUNT(*) FROM emails").fetchone()

--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -8,16 +8,23 @@ Design decisions:
 - SMTP address resolution handles Exchange (on-prem / O365) where
   SenderEmailAddress may return a cryptic X.500/EX address instead of SMTP.
 - is_running() checks the process list without starting Outlook, which is
-  important for the fast-launch requirement.
+  important for the fast-launch requirement. ensure_running() is its deliberate
+  opposite, used only by batch mode, which has no user to open Outlook for it.
+- The batch surface (ensure_running / iter_inbox / find_by_message_id /
+  move_to / set_category / clear_category) lives here too, so batch.py stays
+  pure orchestration and can be driven by a fake client in tests.
 """
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from email_archiver.text import clean_subject as _clean_subject
+from email_archiver.text import normalize_message_id
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +40,75 @@ class EmailData:
     raw_item: Any = None           # the COM MailItem – only used by archiver
 
 
+@dataclass
+class InboxMail:
+    """One live Outlook mail, as batch mode sees it.
+
+    Everything the batch verbs need is read off the COM item once, here, so the
+    orchestration layer never touches COM. ``item`` is the only COM reference
+    that escapes, and only because the archiver needs the real MailItem to call
+    ``SaveAs``.
+    """
+
+    message_id: str = ""           # normalised; "" when the mail carries none
+    entry_id: str = ""
+    subject: str = ""              # cleaned (Re:/Fwd: stripped)
+    sender: str = ""
+    recipients: str = ""
+    date_sent: datetime | None = None
+    body_preview: str = ""
+    attachment_count: int = 0
+    flag_status: int = 0
+    item: Any = None
+
+
+class OutlookUnavailableError(RuntimeError):
+    """Outlook could not be reached — batch mode cannot start.
+
+    Distinct from "there is nothing to do": this means the COM object model
+    never answered, so the caller must exit non-zero rather than report an
+    empty Inbox it never actually read.
+    """
+
+
 # -------------------------------------------------------------- helpers -----
+
+
+def _safe_com(read: Any, default: Any) -> Any:
+    """Read one COM property, returning ``default`` if it raises.
+
+    COM properties on a real mailbox fail for reasons that are not this app's
+    business (an item still downloading, a store that denies a property, an
+    add-in that broke one). A single missing field must degrade that field, not
+    abort a batch run over the whole Inbox.
+    """
+    try:
+        return read()
+    except Exception:
+        return default
+
+
+def _sent_datetime(mail_item: Any) -> datetime | None:
+    """The mail's sent time as a stdlib datetime, or ``None``.
+
+    Tries ``SentOn`` (when it was actually sent) before ``ReceivedTime``, the
+    same order ``archiver._get_sent_date_prefix`` uses, so the date a plan
+    reports and the date a ``YYYY-MM-DD -`` prefix carries cannot disagree.
+    pywintypes datetimes are rebuilt field by field rather than passed through,
+    which is what the caller sees as a plain ``datetime``.
+    """
+    for attr in ("SentOn", "ReceivedTime"):
+        value = _safe_com(lambda a=attr: getattr(mail_item, a), None)
+        if value is None:
+            continue
+        try:
+            return datetime(
+                value.year, value.month, value.day,
+                value.hour, value.minute, value.second,
+            )
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return None
 
 
 def _resolve_smtp(address_entry: Any) -> str:
@@ -145,6 +220,108 @@ def _tasklist_has_image(image_name: str) -> bool:
     return image_name.upper() in result.stdout.upper()
 
 
+# --------------------------------------------------- batch-mode helpers ----
+
+# olFolderInbox. Batch mode reads exactly one folder and files out of it.
+OL_FOLDER_INBOX = 6
+# MailItem. Anything else in the Inbox (meeting requests, reports) is skipped.
+OL_CLASS_MAIL_ITEM = 43
+# DASL name for MAPI PR_INTERNET_MESSAGE_ID (0x1035001F), used both to read the
+# id off a live item and to build the server-side Restrict filter.
+DASL_INTERNET_MESSAGE_ID = (
+    "http://schemas.microsoft.com/mapi/proptag/0x1035001F"
+)
+# DASL name for MAPI PidTagFlagStatus (0x1090), the same property the scanner
+# reads back out of the archived .msg — so a plan and a later scan agree.
+DASL_FLAG_STATUS = "http://schemas.microsoft.com/mapi/proptag/0x10900003"
+
+# How long ensure_running() waits for a freshly launched Outlook to publish its
+# COM object. Outlook's first start on a cold profile is genuinely slow.
+DEFAULT_START_TIMEOUT_SECONDS = 60.0
+_POLL_INTERVAL_SECONDS = 1.0
+
+
+def split_categories(raw: str | None) -> list[str]:
+    """Split Outlook's semicolon-separated Categories string into a list."""
+    if not raw:
+        return []
+    return [part.strip() for part in str(raw).split(";") if part.strip()]
+
+
+def join_categories(names: list[str]) -> str:
+    """Join category names back into the form Outlook stores."""
+    return "; ".join(names)
+
+
+def with_category(raw: str | None, name: str) -> str:
+    """Return the Categories string with ``name`` present exactly once.
+
+    Kept pure and separate from the COM call so the add/remove arithmetic — the
+    part that can silently drop a user's own categories — is unit-testable
+    without Outlook. Existing categories are preserved in order.
+    """
+    names = split_categories(raw)
+    if not any(n.casefold() == name.casefold() for n in names):
+        names.append(name)
+    return join_categories(names)
+
+
+def without_category(raw: str | None, name: str) -> str:
+    """Return the Categories string with ``name`` removed, others untouched."""
+    return join_categories(
+        [n for n in split_categories(raw) if n.casefold() != name.casefold()]
+    )
+
+
+def _outlook_executable() -> str | None:
+    """Path to the registered outlook.exe, or None when it cannot be found.
+
+    Reads the ``App Paths`` registry entry Windows itself uses to resolve
+    ``outlook.exe``, falling back to a PATH lookup. Deliberately not
+    ``Dispatch("Outlook.Application")``: Dispatch starts a *hidden* instance
+    that behaves differently (no explorer, add-ins in a different state) and
+    that the user cannot see or interact with.
+    """
+    import shutil  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    if sys.platform == "win32":
+        try:
+            import winreg  # noqa: PLC0415
+
+            for hive in (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE):
+                try:
+                    with winreg.OpenKey(
+                        hive,
+                        r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
+                        r"\OUTLOOK.EXE",
+                    ) as key:
+                        path, _ = winreg.QueryValueEx(key, "")
+                        if path:
+                            return str(path).strip('"')
+                except OSError:
+                    continue
+        except ImportError:  # pragma: no cover - winreg ships with CPython
+            pass
+
+    return shutil.which("outlook.exe")
+
+
+def _get_active_application() -> Any | None:
+    """Return the running Outlook Application, or None if none is published.
+
+    ``GetActiveObject`` only ever attaches to an Outlook the user (or we)
+    started; unlike ``Dispatch`` it never starts one, which is what makes it
+    safe to call in a poll loop.
+    """
+    try:
+        import win32com.client  # noqa: PLC0415
+
+        return win32com.client.GetActiveObject("Outlook.Application")
+    except Exception:
+        return None
+
+
 # ------------------------------------------------------------- client ------
 
 
@@ -227,25 +404,276 @@ class OutlookClient:
             return None
 
         try:
-            date_sent: datetime | None = None
-            try:
-                # ReceivedTime is a pywintypes datetime; convert to stdlib
-                rt = item.ReceivedTime
-                date_sent = datetime(
-                    rt.year, rt.month, rt.day,
-                    rt.hour, rt.minute, rt.second
-                )
-            except Exception:
-                pass
-
             return EmailData(
                 subject=_clean_subject(item.Subject),
                 sender=_get_sender_smtp(item),
                 recipients=_get_recipients_smtp(item),
-                date_sent=date_sent,
+                date_sent=_sent_datetime(item),
                 raw_item=item,
             )
 
         except Exception as exc:
             logger.error("Error extracting email metadata: %s", exc)
             return None
+
+    # ------------------------------------------------------ batch surface ---
+    #
+    # Used only by email_archiver/batch.py. Everything below keeps COM inside
+    # this class: the batch layer receives InboxMail dataclasses and opaque
+    # item handles, so it can be driven end to end by a fake client.
+
+    def ensure_running(
+        self, timeout: float = DEFAULT_START_TIMEOUT_SECONDS
+    ) -> Any:
+        """Return the Outlook Application object, starting Outlook if needed.
+
+        The opposite of ``is_running()``, and used only by batch mode, which
+        runs unattended and has nobody to open Outlook for it. Starts the
+        *registered* ``outlook.exe`` (visible, with its explorer, exactly as
+        the user's own shortcut would) and then polls ``GetActiveObject`` until
+        the COM object appears or ``timeout`` elapses.
+
+        Raises:
+            OutlookUnavailableError: Outlook could not be started or never
+                published its COM object inside the timeout. A loud failure on
+                purpose — every batch verb needs Outlook, so continuing would
+                report an empty Inbox nobody ever read.
+        """
+        app = _get_active_application()
+        if app is not None:
+            return app
+
+        exe = _outlook_executable()
+        if exe is None:
+            raise OutlookUnavailableError(
+                "Outlook is not running and outlook.exe could not be located "
+                "(no App Paths registry entry and not on PATH)."
+            )
+
+        logger.info("Outlook is not running; starting %s", exe)
+        import subprocess  # noqa: PLC0415
+        import sys  # noqa: PLC0415
+
+        try:
+            # Deliberately WITHOUT CREATE_NO_WINDOW: this is the one spawn in
+            # the project whose window is meant to be visible — a hidden
+            # Outlook is exactly what this method exists to avoid.
+            subprocess.Popen(  # noqa: S603
+                [exe],
+                creationflags=(
+                    subprocess.CREATE_NEW_PROCESS_GROUP
+                    if sys.platform == "win32"
+                    else 0
+                ),
+            )
+        except OSError as exc:
+            raise OutlookUnavailableError(
+                f"Could not start Outlook ({exe}): {exc}"
+            ) from exc
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            time.sleep(_POLL_INTERVAL_SECONDS)
+            app = _get_active_application()
+            if app is not None:
+                logger.info("Outlook is up.")
+                return app
+
+        raise OutlookUnavailableError(
+            f"Outlook was started but did not publish its COM object within "
+            f"{timeout:.0f}s. It may be showing a profile or password prompt."
+        )
+
+    def _namespace(self) -> Any:
+        """Return the MAPI namespace of the running Outlook."""
+        app = _get_active_application()
+        if app is None:
+            raise OutlookUnavailableError(
+                "Outlook is no longer reachable over COM."
+            )
+        return app.GetNamespace("MAPI")
+
+    def _inbox(self) -> Any:
+        return self._namespace().GetDefaultFolder(OL_FOLDER_INBOX)
+
+    def _named_folder(self, name: str, *, create: bool = True) -> Any:
+        """Return the folder ``name`` directly under the mailbox root.
+
+        Matched case-insensitively so a mailbox whose Archive folder is spelled
+        differently is still found rather than duplicated. Created when absent
+        and ``create`` is set, because ``apply`` must have somewhere to move a
+        mail it has already written to disk.
+        """
+        root = self._inbox().Parent
+        folders = root.Folders
+        for i in range(1, folders.Count + 1):
+            folder = folders.Item(i)
+            if str(folder.Name).casefold() == name.casefold():
+                return folder
+        if not create:
+            return None
+        logger.info("Creating Outlook folder %r under %s", name, root.Name)
+        return folders.Add(name)
+
+    def _resolve_folder(self, folder_name: str | None) -> Any:
+        """Inbox for ``None``, else the named folder under the mailbox root."""
+        return self._inbox() if folder_name is None else self._named_folder(folder_name)
+
+    def iter_inbox(self, preview_len: int = 500) -> Iterator[InboxMail]:
+        """Yield every MailItem in the Inbox as an :class:`InboxMail`.
+
+        ``preview_len`` is the scanner's ``scanning.body_preview_length`` so the
+        preview a plan shows and the preview the index stores are the same
+        string. Non-mail items (meeting requests, delivery reports) are skipped:
+        they have no ``SaveAs``-able shape this app archives.
+        """
+        yield from self._iter_folder(self._inbox(), preview_len)
+
+    def _iter_folder(self, folder: Any, preview_len: int) -> Iterator[InboxMail]:
+        import win32com.client  # noqa: PLC0415
+
+        items = folder.Items
+        # Index rather than `for item in items`: the collection is live, and a
+        # positional walk keeps the enumeration stable while the mails sit
+        # still (batch mode never moves anything during a plan).
+        for i in range(1, items.Count + 1):
+            try:
+                raw = items.Item(i)
+                if raw.Class != OL_CLASS_MAIL_ITEM:
+                    continue
+                # Dispatch forces full interface resolution → a MailItem with
+                # SaveAs, the same reason get_selected_mail_item does it.
+                yield self._read_mail(win32com.client.Dispatch(raw), preview_len)
+            except Exception as exc:
+                logger.warning("Skipping unreadable item %d in folder: %s", i, exc)
+
+    def read_mail(self, item: Any, preview_len: int = 0) -> InboxMail:
+        """Read one already-obtained MailItem into an :class:`InboxMail`.
+
+        ``apply`` needs the mail's cleaned subject for the filename after it has
+        found the item by Message-ID; ``preview_len`` defaults to 0 because that
+        path has no use for the body.
+        """
+        return self._read_mail(item, preview_len)
+
+    def _read_mail(self, item: Any, preview_len: int) -> InboxMail:
+        """Read every field batch mode needs off one COM MailItem."""
+        return InboxMail(
+            message_id=self._message_id(item),
+            entry_id=_safe_com(lambda: str(item.EntryID), ""),
+            subject=_clean_subject(_safe_com(lambda: item.Subject, "")),
+            sender=_get_sender_smtp(item),
+            recipients=_get_recipients_smtp(item),
+            date_sent=_sent_datetime(item),
+            body_preview=_safe_com(lambda: (item.Body or "")[:preview_len], ""),
+            attachment_count=_safe_com(lambda: int(item.Attachments.Count), 0),
+            flag_status=self._flag_status(item),
+            item=item,
+        )
+
+    @staticmethod
+    def _message_id(item: Any) -> str:
+        """The mail's normalised Internet Message-ID, or ``""`` when it has none."""
+        return normalize_message_id(
+            _safe_com(
+                lambda: item.PropertyAccessor.GetProperty(DASL_INTERNET_MESSAGE_ID),
+                None,
+            )
+        )
+
+    @staticmethod
+    def _flag_status(item: Any) -> int:
+        """Outlook's follow-up flag, read from the same MAPI property the
+        scanner reads back out of the archived .msg (0x1090). Absent means
+        unflagged, so 0 is a real answer, not a swallowed error."""
+        value = _safe_com(
+            lambda: item.PropertyAccessor.GetProperty(DASL_FLAG_STATUS), None
+        )
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def find_by_message_id(
+        self, message_id: str, folder_name: str | None = None
+    ) -> Any | None:
+        """Return the MailItem with this Message-ID in a folder, or ``None``.
+
+        ``folder_name`` is ``None`` for the Inbox, else a folder under the
+        mailbox root. An empty ``message_id`` never matches — a mail with no
+        Message-ID has no identity to search by, and matching every such mail
+        against each other would file the wrong one.
+
+        Tries a server-side ``Restrict`` first (an Archive folder holds
+        thousands of mails), falling back to a linear walk when the filter
+        cannot be built or the store rejects it.
+        """
+        if not message_id:
+            return None
+        folder = self._resolve_folder(folder_name)
+        if folder is None:
+            return None
+
+        import win32com.client  # noqa: PLC0415
+
+        # A quote inside the id would break out of the DASL string literal;
+        # such ids are vanishingly rare and the linear walk handles them.
+        if "'" not in message_id and '"' not in message_id:
+            for candidate in (f"<{message_id}>", message_id):
+                try:
+                    found = folder.Items.Find(
+                        f"@SQL=\"{DASL_INTERNET_MESSAGE_ID}\" = '{candidate}'"
+                    )
+                except Exception as exc:
+                    logger.debug("Restrict lookup unavailable (%s); walking.", exc)
+                    break
+                if found is not None:
+                    return win32com.client.Dispatch(found)
+
+        # Read *only* the Message-ID while walking. Going through _read_mail
+        # here would resolve every sender and recipient through
+        # GetExchangeUser, which is the one call that can raise Outlook's
+        # address-book security modal — turning a lookup that failed to use the
+        # fast path into a hung process.
+        items = folder.Items
+        for i in range(1, items.Count + 1):
+            try:
+                raw = items.Item(i)
+                if raw.Class != OL_CLASS_MAIL_ITEM:
+                    continue
+                if self._message_id(raw) == message_id:
+                    return win32com.client.Dispatch(raw)
+            except Exception as exc:
+                logger.warning("Skipping unreadable item %d during lookup: %s", i, exc)
+        return None
+
+    def move_to(self, item: Any, folder_name: str | None) -> Any:
+        """Move a mail to a folder and return the moved item.
+
+        ``folder_name`` is ``None`` for the Inbox. The returned object is the
+        item *in its new home* — Outlook rewrites ``EntryID`` on a move, so the
+        caller must read the new id off this object and never off the original
+        reference, which now points at nothing.
+        """
+        target = self._resolve_folder(folder_name)
+        if target is None:
+            raise OutlookUnavailableError(
+                f"Outlook folder {folder_name!r} could not be resolved."
+            )
+        import win32com.client  # noqa: PLC0415
+
+        return win32com.client.Dispatch(item.Move(target))
+
+    def set_category(self, item: Any, name: str) -> None:
+        """Add a category to a mail, preserving any it already carries."""
+        item.Categories = with_category(_safe_com(lambda: item.Categories, ""), name)
+        item.Save()
+
+    def clear_category(self, item: Any, name: str) -> None:
+        """Remove one category from a mail, leaving the others alone."""
+        item.Categories = without_category(_safe_com(lambda: item.Categories, ""), name)
+        item.Save()
+
+    def entry_id(self, item: Any) -> str:
+        """The mail's current EntryID (valid only for its current folder)."""
+        return _safe_com(lambda: str(item.EntryID), "")

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -11,6 +11,10 @@ Design decisions:
   a flagged mail into a task. The flag is written into the .msg at archive time
   by `SaveAs`, so flagging a message *after* it is archived changes nothing --
   the file on disk is a snapshot. Flag first, then archive.
+- Records the Internet Message-ID (`message_id`) so the batch verbs can tell an
+  Inbox mail that is already archived from one that is not, and can pair a
+  revert with the files written for it. Outlook's EntryID cannot serve: it
+  changes when the mail is moved between folders.
 - progress_callback(current, total, current_file) is called after each file
   so the UI can update a progress bar without polling.
 """
@@ -31,6 +35,7 @@ from email_archiver.config import get_archive_roots, get_max_path_length
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
 from email_archiver.text import clean_subject as _clean_subject_base
+from email_archiver.text import normalize_message_id
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +69,35 @@ def _flag_status(msg: object) -> int:
         return 0
 
 
+# MAPI PidTagInternetMessageId, PT_UNICODE. Same key shape as the flag above:
+# the `001F` type suffix is part of the key. extract-msg exposes the header as
+# `.messageId`, but that property is absent on some message classes, so the raw
+# proptag is the fallback rather than the other way round.
+_PR_INTERNET_MESSAGE_ID = "1035001F"
+
+
+def _message_id(msg: object) -> str:
+    """The Internet Message-ID stored in the .msg, normalised, or ``""``.
+
+    This is the identity the batch verbs pair a live Outlook mail with the file
+    archived from it: Outlook's ``EntryID`` changes the moment a mail is moved
+    between folders, the Message-ID does not. ``""`` means the file carries no
+    such header (rare -- drafts, some system mail), which is a real answer the
+    batch layer reports rather than a read failure.
+    """
+    raw = None
+    try:
+        raw = msg.messageId
+    except (AttributeError, TypeError, ValueError):
+        raw = None
+    if not raw:
+        try:
+            raw = msg.getPropertyVal(_PR_INTERNET_MESSAGE_ID)
+        except (AttributeError, TypeError, ValueError):
+            raw = None
+    return normalize_message_id(raw)
+
+
 def _extract_msg_metadata(
     file_path: str, body_preview_len: int
 ) -> dict[str, object] | None:
@@ -95,6 +129,7 @@ def _extract_msg_metadata(
                 "body_preview": body,
                 "date_sent": date_sent,
                 "flag_status": _flag_status(msg),
+                "message_id": _message_id(msg),
             }
 
     except (InvalidFileFormatError, UnrecognizedMSGTypeError) as exc:

--- a/email_archiver/text.py
+++ b/email_archiver/text.py
@@ -17,6 +17,30 @@ RE_REPLY_PREFIX = re.compile(r"^\s*(re|rv|fwd?)\s*:?\s*", re.IGNORECASE)
 _RE_MSG_SUFFIX = re.compile(r"\s*\.msg$", re.IGNORECASE)
 
 
+def normalize_message_id(raw: str | None) -> str:
+    """Return the Internet Message-ID in the one canonical form this app stores.
+
+    Two sources have to agree on it or the batch verbs cannot pair a live mail
+    with the file archived from it: Outlook COM reads MAPI
+    ``PR_INTERNET_MESSAGE_ID`` (``0x1035001F``) off the live item, while the
+    scanner reads the same header back out of the ``.msg`` on disk. Both spell
+    it ``<local@domain>`` most of the time, but neither guarantees the angle
+    brackets or the surrounding whitespace, so the stored form drops both.
+
+    Case is deliberately preserved: RFC 5322 makes the left-hand side of a
+    Message-ID case-sensitive, so folding it would merge ids that are genuinely
+    distinct. Returns ``""`` for a missing or empty id -- a real answer ("this
+    mail has no Message-ID"), which the caller reports and skips rather than
+    treating as an identity.
+    """
+    if not raw:
+        return ""
+    s = str(raw).strip()
+    if s.startswith("<") and s.endswith(">") and len(s) > 1:
+        s = s[1:-1].strip()
+    return s
+
+
 def clean_subject(raw: str | None, *, strip_msg_suffix: bool = False) -> str:
     """Return a normalised subject string.
 

--- a/main_batch.py
+++ b/main_batch.py
@@ -138,8 +138,14 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         cfg = load_config()
-    except (FileNotFoundError, KeyError) as exc:
-        return _fail(verb, ERROR_CONFIG_MISSING, str(exc))
+    except Exception as exc:
+        # Deliberately broad: this process's whole contract is "exit 2 with a
+        # JSON error document when the run cannot start". A malformed YAML, an
+        # unreadable path, a missing section — anything that stops the config
+        # loading has to come out as that document, not as a traceback on
+        # stderr with nothing on stdout, which is what a spawning caller would
+        # see as a crash it cannot classify.
+        return _fail(verb, ERROR_CONFIG_MISSING, f"{type(exc).__name__}: {exc}")
     setup_logging(cfg)
 
     # Read the caller's input before touching Outlook: a malformed file should

--- a/main_batch.py
+++ b/main_batch.py
@@ -1,0 +1,192 @@
+"""
+Headless batch entry point – plan / apply / revert the whole Outlook Inbox.
+
+Meant to be spawned as a subprocess by another local app (task-os), never used
+interactively: every verb prints exactly one JSON document on stdout, logs to
+the usual log file and to stderr, and never opens a window.
+
+    python main_batch.py plan --candidates 5 > plan.json
+    python main_batch.py apply --decisions decisions.json
+    python main_batch.py revert --items revert.json
+
+Exit codes:
+    0  the run completed and stdout carries its document — individual mails may
+       still have failed, each with its own `error` inside the document
+    2  the run could not start: no config, unreadable input, or Outlook
+       unreachable. stdout carries `{"error": {"code", "message"}}` instead
+
+Why a separate process rather than a library call: every verb drives Outlook
+over COM, and a COM modal (the address-book security prompt, a profile chooser)
+blocks whatever thread it is raised on. Spawning this with a timeout means such
+a prompt hangs *this* process, which the caller can kill, and never the caller.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+# Ensure project root is on the path regardless of cwd
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from email_archiver import batch
+from email_archiver.config import load_config, setup_logging
+from email_archiver.outlook.client import (
+    DEFAULT_START_TIMEOUT_SECONDS,
+    OutlookClient,
+    OutlookUnavailableError,
+)
+
+logger = logging.getLogger(__name__)
+
+EXIT_OK = 0
+EXIT_CANNOT_START = 2
+
+ERROR_CONFIG_MISSING = "config_missing"
+ERROR_BAD_INPUT = "bad_input"
+ERROR_OUTLOOK_UNAVAILABLE = "outlook_unavailable"
+ERROR_COM_UNAVAILABLE = "com_unavailable"
+
+
+def _emit(document: dict[str, Any]) -> None:
+    """Print the one JSON document this process produces.
+
+    stdout is reconfigured to UTF-8 first: under a pipe Python falls back to the
+    console code page, and a single accented subject would otherwise raise
+    UnicodeEncodeError and kill a run that had already moved mail.
+    """
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):  # pragma: no cover - defensive
+        pass
+    json.dump(document, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def _fail(verb: str, code: str, message: str) -> int:
+    logger.error("%s: %s", code, message)
+    _emit(batch.error_document(verb, code, message))
+    return EXIT_CANNOT_START
+
+
+def _load_input(path: str) -> list[dict[str, Any]]:
+    """Read a decisions / items file into a list of dicts.
+
+    Accepts either a bare JSON list or an object carrying one under
+    ``decisions`` / ``items`` / ``results`` — the last so an `apply` document
+    can be handed straight back to `revert` without being reshaped.
+    """
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        for key in ("decisions", "items", "results"):
+            if isinstance(data.get(key), list):
+                data = data[key]
+                break
+        else:
+            raise ValueError(
+                "expected a JSON list, or an object with a decisions/items/"
+                "results list"
+            )
+    if not isinstance(data, list):
+        raise ValueError("expected a JSON list of objects")
+    bad = [i for i, entry in enumerate(data) if not isinstance(entry, dict)]
+    if bad:
+        raise ValueError(f"entries at index {bad[:5]} are not JSON objects")
+    return data
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="main_batch.py",
+        description="Plan, apply or revert archiving of the whole Outlook Inbox.",
+    )
+    parser.add_argument(
+        "--start-timeout", type=float, default=DEFAULT_START_TIMEOUT_SECONDS,
+        help="Seconds to wait for a freshly started Outlook to answer over COM "
+             "(default: %(default)s).",
+    )
+    sub = parser.add_subparsers(dest="verb", required=True)
+
+    p_plan = sub.add_parser("plan", help="List every Inbox mail with ranked folders.")
+    p_plan.add_argument(
+        "--candidates", type=int, default=batch.DEFAULT_CANDIDATES,
+        help="Ranked folder candidates per mail (default: %(default)s).",
+    )
+
+    p_apply = sub.add_parser("apply", help="Archive, move and tag decided mails.")
+    p_apply.add_argument(
+        "--decisions", required=True,
+        help="JSON file: [{message_id, folder_path, date_prefix}, ...]",
+    )
+
+    p_revert = sub.add_parser("revert", help="Undo an apply: delete files, move back.")
+    p_revert.add_argument(
+        "--items", required=True,
+        help="JSON file: [{message_id, files: [...]}, ...]",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    verb: str = args.verb
+
+    try:
+        cfg = load_config()
+    except (FileNotFoundError, KeyError) as exc:
+        return _fail(verb, ERROR_CONFIG_MISSING, str(exc))
+    setup_logging(cfg)
+
+    # Read the caller's input before touching Outlook: a malformed file should
+    # fail in milliseconds, not after a 60-second Outlook start.
+    payload: list[dict[str, Any]] = []
+    if verb in ("apply", "revert"):
+        source = args.decisions if verb == "apply" else args.items
+        try:
+            payload = _load_input(source)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            return _fail(verb, ERROR_BAD_INPUT, f"{source}: {exc}")
+
+    if args.start_timeout <= 0:
+        return _fail(verb, ERROR_BAD_INPUT, "--start-timeout must be positive")
+    if verb == "plan" and args.candidates < 1:
+        return _fail(verb, ERROR_BAD_INPUT, "--candidates must be at least 1")
+
+    try:
+        import pythoncom  # noqa: PLC0415
+    except ImportError as exc:
+        return _fail(
+            verb, ERROR_COM_UNAVAILABLE,
+            f"pywin32 is not available, so Outlook cannot be reached: {exc}",
+        )
+
+    # Single-threaded apartment on the one thread this process has. Every COM
+    # call below happens here; nothing is handed to a worker.
+    pythoncom.CoInitialize()
+    try:
+        client = OutlookClient()
+        try:
+            client.ensure_running(timeout=args.start_timeout)
+        except OutlookUnavailableError as exc:
+            return _fail(verb, ERROR_OUTLOOK_UNAVAILABLE, str(exc))
+
+        if verb == "plan":
+            document = batch.plan(client, cfg, candidates=args.candidates)
+        elif verb == "apply":
+            document = batch.apply(client, cfg, payload)
+        else:
+            document = batch.revert(client, cfg, payload)
+    finally:
+        pythoncom.CoUninitialize()
+
+    _emit(document)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,598 @@
+"""Tests for headless batch mode (issue #53).
+
+Batch mode is what another local app spawns to file the whole Inbox in one run,
+so its JSON documents are an interface, not an implementation detail: a
+consumer parses them without a human reading the output. These tests drive
+every verb end to end through a fake Outlook client — real archiver, real
+suggestion engine, real SQLite index, fake COM — and pin the parts a consumer
+depends on:
+
+- the shapes of the three documents, and that a per-mail failure is *reported*
+  rather than fatal;
+- already-archived detection, which is the only thing stopping a second run
+  from filing the same mail twice;
+- the per-decision ``date_prefix``, which must beat the global config toggle
+  because the caller infers the form the destination folder actually uses;
+- ``revert`` refusing to delete anything outside the configured archive roots.
+
+Everything on screen here is synthetic: no real folder name, address or subject.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from email_archiver import batch
+from email_archiver.database.models import init_db
+from email_archiver.database.repository import EmailRecord, EmailRepository
+from email_archiver.outlook.client import (
+    InboxMail,
+    with_category,
+    without_category,
+)
+
+
+# --------------------------------------------------------------- fake COM ---
+
+class _FakePropertyAccessor:
+    """Raises for an absent property, exactly as Outlook's does."""
+
+    def __init__(self, props: dict[str, object]) -> None:
+        self._props = props
+
+    def GetProperty(self, key: str):  # noqa: N802 - COM's spelling
+        if key in self._props:
+            return self._props[key]
+        raise RuntimeError(f"property not found: {key}")
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"attachment") -> None:
+        self.FileName = filename
+        self.PropertyAccessor = _FakePropertyAccessor({})
+        self._payload = payload
+
+    def SaveAsFile(self, path: str) -> None:  # noqa: N802 - COM's spelling
+        Path(path).write_bytes(self._payload)
+
+
+class _FakeMailItem:
+    """The slice of a COM MailItem the archiver and the client actually touch."""
+
+    def __init__(
+        self,
+        *,
+        message_id: str,
+        subject: str,
+        sender: str = "sender@example.invalid",
+        recipients: str = "me@example.invalid",
+        sent: datetime | None = None,
+        attachments: list[_FakeAttachment] | None = None,
+        flag_status: int = 0,
+    ) -> None:
+        self.message_id = message_id
+        self.Subject = subject
+        self.sender = sender
+        self.recipients = recipients
+        self.SentOn = sent or datetime(2026, 3, 14, 9, 30, 0)
+        self.Attachments = attachments or []
+        self.Categories = ""
+        self.EntryID = f"entry-{message_id or 'none'}"
+        self.flag_status = flag_status
+        self.saved_as: list[str] = []
+        self.save_calls = 0
+
+    def SaveAs(self, path: str, fmt: int) -> None:  # noqa: N802 - COM's spelling
+        Path(path).write_text("synthetic .msg", encoding="utf-8")
+        self.saved_as.append(path)
+
+    def Save(self) -> None:  # noqa: N802 - COM's spelling
+        self.save_calls += 1
+
+
+class FakeOutlookClient:
+    """Stands in for OutlookClient's batch surface.
+
+    Folders are plain lists keyed by name, with ``None`` meaning the Inbox —
+    the same convention the real client uses, so the orchestration under test is
+    the orchestration that ships.
+    """
+
+    def __init__(self, inbox: list[_FakeMailItem]) -> None:
+        self.folders: dict[str | None, list[_FakeMailItem]] = {None: list(inbox)}
+        self.move_should_fail = False
+        self.moves: list[tuple[str, str | None]] = []
+
+    # -- the surface batch.py calls -------------------------------------------
+
+    def iter_inbox(self, preview_len: int = 500):
+        for item in list(self.folders[None]):
+            yield self.read_mail(item, preview_len)
+
+    def read_mail(self, item: _FakeMailItem, preview_len: int = 0) -> InboxMail:
+        return InboxMail(
+            message_id=item.message_id,
+            entry_id=item.EntryID,
+            subject=item.Subject,
+            sender=item.sender,
+            recipients=item.recipients,
+            date_sent=item.SentOn,
+            body_preview=("synthetic body " * 40)[:preview_len],
+            attachment_count=len(item.Attachments),
+            flag_status=item.flag_status,
+            item=item,
+        )
+
+    def find_by_message_id(self, message_id: str, folder_name: str | None = None):
+        if not message_id:
+            return None
+        for item in self.folders.get(folder_name, []):
+            if item.message_id == message_id:
+                return item
+        return None
+
+    def move_to(self, item: _FakeMailItem, folder_name: str | None):
+        if self.move_should_fail:
+            raise RuntimeError("the store refused the move")
+        for name, items in self.folders.items():
+            if item in items:
+                items.remove(item)
+                self.moves.append((item.message_id, folder_name))
+                break
+        self.folders.setdefault(folder_name, []).append(item)
+        # Outlook rewrites EntryID on a move; a fake that did not would let a
+        # bug reading the pre-move id pass unnoticed.
+        item.EntryID = f"entry-{item.message_id}-in-{folder_name or 'inbox'}"
+        return item
+
+    def set_category(self, item: _FakeMailItem, name: str) -> None:
+        item.Categories = with_category(item.Categories, name)
+        item.Save()
+
+    def clear_category(self, item: _FakeMailItem, name: str) -> None:
+        item.Categories = without_category(item.Categories, name)
+        item.Save()
+
+    def entry_id(self, item: _FakeMailItem) -> str:
+        return item.EntryID
+
+
+# --------------------------------------------------------------- fixtures ---
+
+@pytest.fixture
+def archive_root(tmp_path) -> Path:
+    root = tmp_path / "archive"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def cfg(tmp_path, archive_root) -> dict:
+    return {
+        "archive": {"root_paths": [str(archive_root)]},
+        "database": {"path": str(tmp_path / "emails.db")},
+        "scanning": {"batch_size": 500, "body_preview_length": 500},
+        "suggestion": {"max_suggestions": 3, "min_score": 0.0},
+        "naming": {"date_prefix": False},
+        "outlook": {"archive_folder": "Archive", "category": "Filed by batch"},
+        "path": {"max_length": 255},
+    }
+
+
+def _seed_index(cfg: dict, archive_root: Path, folders: dict[str, list[str]]) -> None:
+    """Put synthetic archived mail in the index so the engine has something to
+    rank. ``folders`` maps a folder name to the subjects it already holds."""
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    n = 0
+    for folder, subjects in folders.items():
+        folder_path = str(archive_root / folder)
+        for subject in subjects:
+            n += 1
+            repo.upsert_email(EmailRecord(
+                file_path=f"{folder_path}/{n:03d} - seed.msg",
+                folder_path=folder_path,
+                filename=f"{n:03d} - seed.msg",
+                subject=subject,
+                sender="sender@example.invalid",
+                recipients="me@example.invalid",
+                date_sent="2026-01-01T00:00:00",
+                body_preview=subject,
+                file_mtime=float(n),
+                message_id=f"seed-{n}@example.invalid",
+            ))
+    conn.commit()
+    conn.close()
+
+
+def _mail(message_id: str, subject: str, **kw) -> _FakeMailItem:
+    return _FakeMailItem(message_id=message_id, subject=subject, **kw)
+
+
+# ------------------------------------------------------------------- plan ---
+
+def test_plan_lists_every_inbox_mail_with_ranked_candidates(cfg, archive_root):
+    _seed_index(cfg, archive_root, {
+        "Project Alpha": ["Project Alpha kickoff", "Project Alpha budget"],
+        "Project Beta": ["Project Beta retro"],
+    })
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "Project Alpha weekly update"),
+        _mail("b@example.invalid", "Project Beta retro follow-up"),
+    ])
+
+    doc = batch.plan(client, cfg, candidates=5)
+
+    assert doc["verb"] == "plan"
+    assert doc["schema_version"] == batch.SCHEMA_VERSION
+    assert doc["archive_folder"] == "Archive"
+    assert doc["counts"] == {
+        "inbox": 2, "planned": 2, "already_archived": 0, "skipped": 0,
+    }
+    assert [m["message_id"] for m in doc["mails"]] == [
+        "a@example.invalid", "b@example.invalid",
+    ]
+
+    first = doc["mails"][0]
+    assert set(first) == {
+        "message_id", "entry_id", "subject", "sender", "recipients", "date_sent",
+        "body_preview", "attachment_count", "flag_status", "already_archived",
+        "candidates",
+    }
+    assert first["already_archived"] is None
+    assert first["candidates"], "a seeded index must produce candidates"
+    assert set(first["candidates"][0]) == {
+        "folder_path", "display_name", "score", "match_count", "sample_subjects",
+    }
+    assert first["candidates"][0]["folder_path"] == str(archive_root / "Project Alpha")
+
+
+def test_plan_honours_the_candidate_cap_not_the_config(cfg, archive_root):
+    """--candidates is the caller's, and must beat suggestion.max_suggestions."""
+    _seed_index(cfg, archive_root, {
+        f"Project {n}": [f"Project {n} status report"] for n in range(1, 6)
+    })
+    client = FakeOutlookClient([_mail("a@example.invalid", "Project status report")])
+
+    assert cfg["suggestion"]["max_suggestions"] == 3
+    doc = batch.plan(client, cfg, candidates=1)
+    assert len(doc["mails"][0]["candidates"]) == 1
+    # And the shared config was not mutated on the way through.
+    assert cfg["suggestion"]["max_suggestions"] == 3
+
+
+def test_plan_marks_an_already_archived_mail_and_offers_no_candidates(
+    cfg, archive_root
+):
+    _seed_index(cfg, archive_root, {"Project Alpha": ["Project Alpha kickoff"]})
+    conn = init_db(cfg["database"]["path"])
+    EmailRepository(conn).upsert_email(EmailRecord(
+        file_path=str(archive_root / "Project Alpha" / "007 - already.msg"),
+        folder_path=str(archive_root / "Project Alpha"),
+        filename="007 - already.msg",
+        subject="Project Alpha weekly update",
+        file_mtime=99.0,
+        message_id="a@example.invalid",
+    ))
+    conn.commit()
+    conn.close()
+
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "Project Alpha weekly update"),
+        _mail("b@example.invalid", "Project Alpha budget question"),
+    ])
+    doc = batch.plan(client, cfg, candidates=5)
+
+    archived, fresh = doc["mails"]
+    assert archived["already_archived"] == str(
+        archive_root / "Project Alpha" / "007 - already.msg"
+    )
+    assert archived["candidates"] == []
+    assert fresh["already_archived"] is None
+    assert doc["counts"]["already_archived"] == 1
+    assert doc["counts"]["planned"] == 1
+
+
+def test_plan_reports_a_mail_with_no_message_id_as_skipped(cfg, archive_root):
+    """A mail with no identity is reported, never guessed at."""
+    _seed_index(cfg, archive_root, {"Project Alpha": ["Project Alpha kickoff"]})
+    client = FakeOutlookClient([
+        _mail("", "A draft with no Message-ID"),
+        _mail("b@example.invalid", "Project Alpha budget"),
+    ])
+
+    doc = batch.plan(client, cfg, candidates=5)
+
+    assert doc["counts"] == {
+        "inbox": 2, "planned": 1, "already_archived": 0, "skipped": 1,
+    }
+    assert doc["skipped"] == [{
+        "entry_id": "entry-none",
+        "subject": "A draft with no Message-ID",
+        "reason": batch.SKIP_NO_MESSAGE_ID,
+    }]
+    assert [m["message_id"] for m in doc["mails"]] == ["b@example.invalid"]
+
+
+def test_plan_on_an_empty_inbox_is_an_empty_document_not_an_error(cfg):
+    doc = batch.plan(FakeOutlookClient([]), cfg)
+    assert doc["counts"]["inbox"] == 0
+    assert doc["mails"] == []
+
+
+# ------------------------------------------------------------------ apply ---
+
+def test_apply_writes_the_bundle_moves_the_mail_and_tags_it(cfg, archive_root):
+    dest = archive_root / "Project Alpha"
+    item = _mail(
+        "a@example.invalid", "Project Alpha weekly update",
+        attachments=[_FakeAttachment("report.pdf")],
+    )
+    client = FakeOutlookClient([item])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest),
+         "date_prefix": False},
+    ])
+
+    assert doc["verb"] == "apply"
+    assert doc["counts"] == {"requested": 1, "applied": 1, "failed": 0}
+    result = doc["results"][0]
+    assert set(result) == {
+        "message_id", "folder_path", "ok", "sequence_number", "files",
+        "entry_id", "moved", "categorized", "error",
+    }
+    assert result["ok"] is True
+    assert result["error"] is None
+    assert result["sequence_number"] == "001"
+    assert [Path(p).name for p in result["files"]] == [
+        "001 - Project Alpha weekly update.msg", "001 - report.pdf",
+    ]
+    assert all(Path(p).exists() for p in result["files"])
+
+    # Moved out of the Inbox, into the configured folder, with the category.
+    assert client.folders[None] == []
+    assert client.folders["Archive"] == [item]
+    assert item.Categories == "Filed by batch"
+    # The reported EntryID is the post-move one, never the stale Inbox id.
+    assert result["entry_id"] == "entry-a@example.invalid-in-Archive"
+
+
+def test_apply_uses_the_per_decision_date_prefix_over_the_config(cfg, archive_root):
+    """The caller owns the naming form; the global toggle is not consulted."""
+    dest = archive_root / "Project Alpha"
+    assert cfg["naming"]["date_prefix"] is False
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "Dated one",
+              sent=datetime(2026, 3, 14, 9, 0, 0)),
+        _mail("b@example.invalid", "Undated one",
+              sent=datetime(2026, 3, 14, 9, 0, 0)),
+    ])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest),
+         "date_prefix": True},
+        {"message_id": "b@example.invalid", "folder_path": str(dest),
+         "date_prefix": False},
+    ])
+
+    dated, undated = (Path(r["files"][0]).name for r in doc["results"])
+    assert dated == "2026-03-14 - 001 - Dated one.msg"
+    assert undated == "002 - Undated one.msg"
+
+
+def test_apply_defaults_date_prefix_to_off_when_the_decision_omits_it(
+    cfg, archive_root
+):
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("a@example.invalid", "No opinion")])
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+    assert Path(doc["results"][0]["files"][0]).name == "001 - No opinion.msg"
+
+
+def test_apply_reports_a_missing_mail_without_aborting_the_run(cfg, archive_root):
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("b@example.invalid", "Present")])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "gone@example.invalid", "folder_path": str(dest)},
+        {"message_id": "b@example.invalid", "folder_path": str(dest)},
+    ])
+
+    assert doc["counts"] == {"requested": 2, "applied": 1, "failed": 1}
+    missing, present = doc["results"]
+    assert missing["ok"] is False
+    assert missing["error"]["code"] == batch.ERROR_NOT_IN_INBOX
+    assert missing["files"] == []
+    assert present["ok"] is True, "one bad decision must not stop the next"
+
+
+def test_apply_rejects_a_decision_with_no_folder(cfg):
+    client = FakeOutlookClient([_mail("a@example.invalid", "Somewhere")])
+    doc = batch.apply(client, cfg, [{"message_id": "a@example.invalid"}])
+    assert doc["results"][0]["error"]["code"] == batch.ERROR_BAD_DECISION
+    assert client.folders[None], "a rejected decision must not move the mail"
+
+
+def test_apply_keeps_the_written_files_when_the_move_fails(cfg, archive_root):
+    """The case that makes an apply result revertible even when it failed."""
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("a@example.invalid", "Half done")])
+    client.move_should_fail = True
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is False
+    assert result["moved"] is False
+    assert result["error"]["code"] == batch.ERROR_MOVE_FAILED
+    assert result["files"] and Path(result["files"][0]).exists(), (
+        "the files are on disk, so the caller must be told about them"
+    )
+
+
+def test_apply_accepts_a_bracketed_message_id_from_the_caller(cfg, archive_root):
+    """A caller echoing a raw header back must still match."""
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("a@example.invalid", "Bracketed")])
+    doc = batch.apply(client, cfg, [
+        {"message_id": "<a@example.invalid>", "folder_path": str(dest)},
+    ])
+    assert doc["results"][0]["ok"] is True
+
+
+# ----------------------------------------------------------------- revert ---
+
+def _apply_one(cfg, archive_root, client, message_id="a@example.invalid"):
+    dest = archive_root / "Project Alpha"
+    return batch.apply(client, cfg, [
+        {"message_id": message_id, "folder_path": str(dest)},
+    ])["results"][0]
+
+
+def test_revert_deletes_the_files_and_puts_the_mail_back(cfg, archive_root):
+    item = _mail(
+        "a@example.invalid", "Round trip",
+        attachments=[_FakeAttachment("report.pdf")],
+    )
+    client = FakeOutlookClient([item])
+    applied = _apply_one(cfg, archive_root, client)
+    assert client.folders["Archive"] == [item]
+
+    doc = batch.revert(client, cfg, [
+        {"message_id": "a@example.invalid", "files": applied["files"]},
+    ])
+
+    assert doc["verb"] == "revert"
+    assert doc["counts"] == {"requested": 1, "reverted": 1, "failed": 0}
+    result = doc["results"][0]
+    assert set(result) == {
+        "message_id", "ok", "deleted", "missing", "refused", "file_errors",
+        "moved_back", "category_removed", "entry_id", "error",
+    }
+    assert result["ok"] is True
+    assert sorted(result["deleted"]) == sorted(str(Path(p)) for p in applied["files"])
+    assert not any(Path(p).exists() for p in applied["files"])
+    assert result["moved_back"] is True
+    assert result["category_removed"] is True
+    assert client.folders[None] == [item]
+    assert client.folders["Archive"] == []
+    assert item.Categories == ""
+
+
+def test_revert_refuses_a_file_outside_the_archive_roots(cfg, tmp_path):
+    """The path-safety guard: a decisions file cannot reach the rest of the disk."""
+    outsider = tmp_path / "not-the-archive" / "precious.txt"
+    outsider.parent.mkdir()
+    outsider.write_text("do not delete me", encoding="utf-8")
+
+    client = FakeOutlookClient([])
+    doc = batch.revert(client, cfg, [
+        {"message_id": "a@example.invalid", "files": [str(outsider)]},
+    ])
+
+    result = doc["results"][0]
+    assert result["deleted"] == []
+    assert result["refused"] == [
+        {"path": str(outsider), "reason": batch.REFUSED_OUTSIDE_ROOTS}
+    ]
+    assert outsider.exists(), "a refused file must still be on disk"
+    assert result["ok"] is False
+
+
+def test_revert_refuses_a_traversal_out_of_an_archive_root(cfg, archive_root, tmp_path):
+    outsider = tmp_path / "precious.txt"
+    outsider.write_text("do not delete me", encoding="utf-8")
+    sneaky = str(archive_root / ".." / "precious.txt")
+
+    doc = batch.revert(FakeOutlookClient([]), cfg, [
+        {"message_id": "a@example.invalid", "files": [sneaky]},
+    ])
+
+    assert doc["results"][0]["refused"][0]["reason"] == batch.REFUSED_OUTSIDE_ROOTS
+    assert outsider.exists()
+
+
+def test_revert_reports_an_already_deleted_file_as_missing_not_an_error(
+    cfg, archive_root
+):
+    """A revert run twice is not a failure to explain."""
+    item = _mail("a@example.invalid", "Twice")
+    client = FakeOutlookClient([item])
+    applied = _apply_one(cfg, archive_root, client)
+    items = [{"message_id": "a@example.invalid", "files": applied["files"]}]
+
+    batch.revert(client, cfg, items)
+    doc = batch.revert(client, cfg, items)
+
+    result = doc["results"][0]
+    assert result["deleted"] == []
+    assert result["missing"] == [str(Path(applied["files"][0]))]
+    assert result["file_errors"] == []
+    # The mail is back in the Inbox already, so it is no longer in Archive.
+    assert result["error"]["code"] == batch.ERROR_NOT_IN_ARCHIVE
+
+
+def test_revert_still_deletes_the_files_when_the_mail_cannot_be_found(
+    cfg, archive_root
+):
+    """Files first, mail second: a mail the user already moved by hand must not
+    strand its files on disk."""
+    item = _mail("a@example.invalid", "Moved by hand")
+    client = FakeOutlookClient([item])
+    applied = _apply_one(cfg, archive_root, client)
+    client.folders["Archive"].clear()
+
+    doc = batch.revert(client, cfg, [
+        {"message_id": "a@example.invalid", "files": applied["files"]},
+    ])
+
+    result = doc["results"][0]
+    assert result["deleted"] == [str(Path(applied["files"][0]))]
+    assert result["moved_back"] is False
+    assert result["error"]["code"] == batch.ERROR_NOT_IN_ARCHIVE
+
+
+def test_revert_needs_a_message_id_to_move_a_mail_back(cfg):
+    doc = batch.revert(FakeOutlookClient([]), cfg, [{"files": []}])
+    assert doc["results"][0]["error"]["code"] == batch.ERROR_BAD_DECISION
+
+
+# ------------------------------------------------------- category handling ---
+
+def test_a_category_is_added_without_losing_the_user_s_own():
+    assert with_category("Red; Blue", "Filed") == "Red; Blue; Filed"
+
+
+def test_adding_a_category_twice_does_not_duplicate_it():
+    assert with_category("Red; Filed", "Filed") == "Red; Filed"
+    assert with_category("Red; filed", "Filed") == "Red; filed"
+
+
+def test_removing_a_category_leaves_the_others_alone():
+    assert without_category("Red; Filed; Blue", "Filed") == "Red; Blue"
+
+
+def test_removing_a_category_that_is_not_there_changes_nothing():
+    assert without_category("Red; Blue", "Filed") == "Red; Blue"
+
+
+def test_the_category_helpers_survive_an_empty_string():
+    assert with_category("", "Filed") == "Filed"
+    assert without_category("", "Filed") == ""
+    assert without_category(None, "Filed") == ""
+
+
+# ------------------------------------------------------- the error envelope --
+
+def test_the_error_document_carries_a_code_and_the_same_envelope():
+    doc = batch.error_document("plan", "outlook_unavailable", "nope")
+    assert doc["verb"] == "plan"
+    assert doc["schema_version"] == batch.SCHEMA_VERSION
+    assert doc["error"] == {"code": "outlook_unavailable", "message": "nope"}

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -103,6 +103,7 @@ class FakeOutlookClient:
     def __init__(self, inbox: list[_FakeMailItem]) -> None:
         self.folders: dict[str | None, list[_FakeMailItem]] = {None: list(inbox)}
         self.move_should_fail = False
+        self.category_should_fail = False
         self.moves: list[tuple[str, str | None]] = []
 
     # -- the surface batch.py calls -------------------------------------------
@@ -148,6 +149,8 @@ class FakeOutlookClient:
         return item
 
     def set_category(self, item: _FakeMailItem, name: str) -> None:
+        if self.category_should_fail:
+            raise RuntimeError("the store refused the category")
         item.Categories = with_category(item.Categories, name)
         item.Save()
 
@@ -435,6 +438,32 @@ def test_apply_keeps_the_written_files_when_the_move_fails(cfg, archive_root):
     assert result["files"] and Path(result["files"][0]).exists(), (
         "the files are on disk, so the caller must be told about them"
     )
+
+
+def test_apply_tells_a_failed_tag_apart_from_a_failed_move(cfg, archive_root):
+    """Two different states to recover from, so two different codes.
+
+    After a move_failed the mail is still in the Inbox; after a
+    category_failed it is already filed and only *looks* untouched in Outlook.
+    Folding the second into the first would send a caller looking in the wrong
+    folder.
+    """
+    dest = archive_root / "Project Alpha"
+    item = _mail("a@example.invalid", "Tagged badly")
+    client = FakeOutlookClient([item])
+    client.category_should_fail = True
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is False
+    assert result["error"]["code"] == batch.ERROR_CATEGORY_FAILED
+    assert result["moved"] is True, "the move did happen and must be reported so"
+    assert result["categorized"] is False
+    assert client.folders["Archive"] == [item], "the mail really is filed"
+    assert result["files"] and Path(result["files"][0]).exists()
 
 
 def test_apply_accepts_a_bracketed_message_id_from_the_caller(cfg, archive_root):

--- a/tests/test_message_id.py
+++ b/tests/test_message_id.py
@@ -1,0 +1,226 @@
+"""Tests for the Internet Message-ID the scanner records (issue #53).
+
+Batch mode pairs a live Outlook mail with the file archived from it by
+Message-ID, because Outlook rewrites ``EntryID`` the moment a mail is moved
+between folders — which is exactly what ``apply`` does to every mail it files.
+Three things have to hold, each with its own failure mode:
+
+- the column exists on an **existing** database, not only a fresh one — the same
+  ``CREATE TABLE IF NOT EXISTS`` no-op that the follow-up flag hit;
+- both sides normalise the id the same way, or a plan reports every already
+  archived mail as new and files it a second time;
+- an empty id never matches. A ``.msg`` with no Message-ID header stores ``""``
+  and a row indexed before the column existed stores NULL; treating either as a
+  match would pair two unrelated mails.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from email_archiver.database.models import _COLUMNS, init_db
+from email_archiver.database.repository import EmailRecord, EmailRepository
+from email_archiver.scanner.scanner import _message_id
+from email_archiver.text import normalize_message_id
+
+# The `emails` table as it shipped before this change.
+_OLD_DDL = """
+CREATE TABLE emails (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path    TEXT    UNIQUE NOT NULL,
+    folder_path  TEXT    NOT NULL,
+    filename     TEXT    NOT NULL,
+    subject      TEXT,
+    sender       TEXT,
+    recipients   TEXT,
+    date_sent    TEXT,
+    body_preview TEXT,
+    file_mtime   REAL    NOT NULL,
+    indexed_at   TEXT    NOT NULL DEFAULT (datetime('now')),
+    flag_status  INTEGER
+);
+"""
+
+
+class _FakeMsg:
+    """Stands in for ``extract_msg.Message``.
+
+    ``messageId`` is a property on the real class and raises AttributeError when
+    the message type does not carry one, which is why the scanner has a proptag
+    fallback at all.
+    """
+
+    def __init__(self, message_id=..., props: dict | None = None) -> None:
+        self._props = props or {}
+        if message_id is not ...:
+            self.messageId = message_id  # noqa: N815 - extract_msg's spelling
+
+    def getPropertyVal(self, key: str):  # noqa: N802 - extract_msg's spelling
+        return self._props.get(key)
+
+
+def _columns(conn: sqlite3.Connection) -> set[str]:
+    return {r["name"] for r in conn.execute("PRAGMA table_info(emails)")}
+
+
+# ------------------------------------------------------------ normalisation --
+
+def test_the_angle_brackets_are_stripped():
+    assert normalize_message_id("<abc123@mail.example>") == "abc123@mail.example"
+
+
+def test_an_id_without_brackets_is_left_alone():
+    assert normalize_message_id("abc123@mail.example") == "abc123@mail.example"
+
+
+def test_surrounding_whitespace_is_stripped():
+    assert normalize_message_id("  <abc123@mail.example>\n") == "abc123@mail.example"
+
+
+def test_case_is_preserved():
+    # RFC 5322 makes the left-hand side case-sensitive; folding it would merge
+    # ids that are genuinely different mails.
+    assert normalize_message_id("<AbC@Mail.Example>") == "AbC@Mail.Example"
+
+
+def test_a_missing_id_is_the_empty_string_not_none():
+    for raw in (None, "", "   ", "<>"):
+        assert normalize_message_id(raw) == ""
+
+
+# --------------------------------------------------------------- the read ----
+
+def test_the_scanner_reads_the_header_extract_msg_exposes():
+    assert _message_id(_FakeMsg("<abc@mail.example>")) == "abc@mail.example"
+
+
+def test_the_scanner_falls_back_to_the_raw_proptag():
+    # Some message classes have no `messageId` property at all.
+    msg = _FakeMsg(props={"1035001F": "<abc@mail.example>"})
+    assert _message_id(msg) == "abc@mail.example"
+
+
+def test_an_empty_property_falls_back_rather_than_returning_blank():
+    msg = _FakeMsg("", props={"1035001F": "<abc@mail.example>"})
+    assert _message_id(msg) == "abc@mail.example"
+
+
+def test_a_message_with_no_id_anywhere_reads_as_empty_not_an_error():
+    assert _message_id(_FakeMsg(None)) == ""
+    assert _message_id(_FakeMsg()) == ""
+
+
+# ------------------------------------------------------------ the migration --
+
+def test_a_fresh_database_has_the_column():
+    conn = init_db(":memory:")
+    assert "message_id" in _columns(conn)
+
+
+def test_an_existing_database_gains_the_column_without_losing_rows(tmp_path):
+    path = str(tmp_path / "emails.db")
+    old = sqlite3.connect(path)
+    old.executescript(_OLD_DDL)
+    old.execute(
+        "INSERT INTO emails (file_path, folder_path, filename, file_mtime)"
+        " VALUES ('a.msg', 'C:/archive', 'a.msg', 1.0)"
+    )
+    old.commit()
+    old.close()
+
+    conn = init_db(path)
+
+    assert "message_id" in _columns(conn)
+    row = conn.execute("SELECT * FROM emails WHERE file_path = 'a.msg'").fetchone()
+    assert row is not None, "the migration must not lose the existing row"
+    assert row["message_id"] is None, (
+        "a row indexed before the header was read must stay NULL -- an empty "
+        "string would claim the mail was read and found to have no Message-ID"
+    )
+
+
+def test_the_index_is_created_after_the_column_exists(tmp_path):
+    """The order that a naive DDL edit gets wrong.
+
+    `init_db` runs `_DDL` before the ALTERs, so an index on `message_id`
+    declared there would be created against a column an existing table does not
+    have yet -- and the whole script would fail, breaking every later scan.
+    """
+    path = str(tmp_path / "emails.db")
+    old = sqlite3.connect(path)
+    old.executescript(_OLD_DDL)
+    old.commit()
+    old.close()
+
+    conn = init_db(path)
+    indexes = {r[1] for r in conn.execute("PRAGMA index_list(emails)")}
+    assert "idx_emails_message_id" in indexes
+
+
+def test_the_migration_is_idempotent(tmp_path):
+    path = str(tmp_path / "emails.db")
+    init_db(path).close()
+    conn = init_db(path)
+    assert "message_id" in _columns(conn)
+
+
+def test_every_migrated_column_is_also_in_the_create_table():
+    fresh = _columns(init_db(":memory:"))
+    assert set(_COLUMNS) <= fresh
+
+
+# ------------------------------------------------------------- the lookup ----
+
+def _repo_with(conn, **overrides) -> EmailRepository:
+    repo = EmailRepository(conn)
+    rec = EmailRecord(
+        file_path="C:/archive/Project Alpha/001 - kickoff.msg",
+        folder_path="C:/archive/Project Alpha",
+        filename="001 - kickoff.msg",
+        file_mtime=1.0,
+    )
+    for key, value in overrides.items():
+        setattr(rec, key, value)
+    repo.upsert_email(rec)
+    conn.commit()
+    return repo
+
+
+def test_a_known_message_id_resolves_to_its_archived_file():
+    conn = init_db(":memory:")
+    repo = _repo_with(conn, message_id="abc@mail.example")
+    assert repo.find_path_by_message_id("abc@mail.example") == (
+        "C:/archive/Project Alpha/001 - kickoff.msg"
+    )
+
+
+def test_an_unknown_message_id_resolves_to_nothing():
+    conn = init_db(":memory:")
+    repo = _repo_with(conn, message_id="abc@mail.example")
+    assert repo.find_path_by_message_id("other@mail.example") is None
+
+
+def test_the_empty_message_id_never_matches():
+    """Two mails with no Message-ID are not the same mail."""
+    conn = init_db(":memory:")
+    repo = _repo_with(conn, message_id="")
+    assert repo.find_path_by_message_id("") is None
+
+
+def test_a_null_row_never_matches_the_empty_id():
+    conn = init_db(":memory:")
+    conn.execute(
+        "INSERT INTO emails (file_path, folder_path, filename, file_mtime)"
+        " VALUES ('a.msg', 'C:/archive', 'a.msg', 1.0)"
+    )
+    conn.commit()
+    assert EmailRepository(conn).find_path_by_message_id("") is None
+
+
+def test_the_id_survives_a_write_and_an_update():
+    conn = init_db(":memory:")
+    repo = _repo_with(conn, message_id="abc@mail.example")
+    # Re-indexing the same path with a corrected id must update, not keep the
+    # stale one -- otherwise a plan pairs the mail with the wrong file forever.
+    _repo_with(conn, message_id="def@mail.example")
+    assert repo.find_path_by_message_id("abc@mail.example") is None
+    assert repo.find_path_by_message_id("def@mail.example") is not None


### PR DESCRIPTION
## Summary

Adds a headless **batch** entry point so another local app can archive the whole Outlook Inbox in one spawned run instead of one selected mail at a time. `main_batch.py` is the process; `email_archiver/batch.py` holds the orchestration (no COM, no tkinter, driven end to end by a fake client in the tests). The archiver stays the sole owner of Outlook COM, the suggestion engine and the naming rules — the caller only decides which folder each mail goes to.

Three verbs, each printing exactly one JSON document on stdout:

- **`plan`** — starts Outlook if it is closed (registered `outlook.exe`, polled on `GetActiveObject`, bounded), enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10). A mail already in the index is reported with `already_archived` and no candidates.
- **`apply`** — reads `[{message_id, folder_path, date_prefix}]`, archives each mail, moves it to the Outlook `Archive` folder and stamps the configured category.
- **`revert`** — reads `[{message_id, files}]`, deletes exactly those files, removes the category and moves the mail back to the Inbox.

Design decisions worth reviewing:

- **Identity is the Internet Message-ID, never `EntryID`.** Outlook rewrites `EntryID` on the very `Move` that `apply` performs, so nothing else survives the three verbs. The scanner now records it (`emails.message_id`) for every `.msg` it indexes — that is what lets `plan` recognise a mail that is already filed rather than offering to file it twice.
- **The `message_id` index is created *after* the ALTER.** Declaring it beside the `CREATE TABLE` would run it against a column an existing database does not have yet (`CREATE TABLE IF NOT EXISTS` is a no-op once the table exists) and take every later scan down with it. There is a test for exactly that ordering.
- **`date_prefix` rides each `apply` decision**, not the global `naming.date_prefix` toggle — the right form depends on the destination folder, which only the caller knows. (The sibling naming-inference issue #54 is what will compute it; nothing of #54 is implemented here.)
- **`apply` fills in a result's `files` before the move**, so a mail written to disk but not moved is still fully revertible. That is why a result can carry `ok: false` and a non-empty `files` at once.
- **`revert` deletes only the files it is given**, and only those resolving inside `archive.root_paths`; anything else is refused per file with a reason and left alone. The four per-file buckets (`deleted` / `missing` / `refused` / `file_errors`) are deliberately distinct facts.
- **Exit 0 with a document even when individual mails failed**; non-zero (2) only when the run could not start, with `{"error": {"code", "message"}}` on stdout so a consumer parses one shape either way — including a malformed `config.yaml`, which must not traceback out with nothing on stdout.
- **`move_failed` and `category_failed` are separate codes.** After the first the mail is still in the Inbox; after the second it is already filed and only *looks* untouched in Outlook. A caller recovers from the two differently.

One thing a consumer must know, stated plainly in the README rather than glossed: **the existing index is not backfilled.** Scanning is incremental on `mtime`, so a `.msg` indexed before `message_id` existed keeps its `NULL` and `plan` is blind to mail filed before this build. Everything archived from here on is indexed with its id on the next scan, so already-archived detection is complete for the batch workflow's own loop; covering the backlog too means forcing a full re-read.

## Validation

Everything below was run on this branch. `[x]` means "ran it and saw it pass".

**Automated gate** (the project's declared gate is `pytest`; this repo has no linter configured, so none was run and none is claimed)

- [x] `& .\.venv\Scripts\python.exe -m pytest tests/` — **106 passed** (62 before this branch, 44 new)
- [x] `& .\.venv\Scripts\python.exe -m compileall -q email_archiver main_batch.py tests` — exit 0
- [x] New tests cover every acceptance point with a fake Outlook client: the three document shapes, already-archived detection, the `no_message_id` skip, the per-decision `date_prefix` beating the config, a per-mail failure not aborting the run, files surviving a failed move, the root-path refusal (including a `..` traversal), a second revert reporting `missing` rather than an error, and the Message-ID migration on a database that predates the column.

**Real-Outlook walk** (classic desktop Outlook, this machine, one mail only)

- [x] Outlook was **closed** when the walk started — `plan` located the registered `outlook.exe`, started it and had the COM object in ~1 s. This is the "Outlook closed at plan time is started and waited for" acceptance point, walked for real.
- [x] `plan --candidates 5` over the live Inbox: 7 mails, all with 5 ranked candidates, 0 already archived, 0 skipped. Read-only. The `message_id` column ALTERed itself into the live ~18k-row index on the way through (`Added column(s) to emails: message_id`).
- [x] `apply` on **exactly one** mail — the highest-scoring candidate in the plan (0.76). Wrote a 5-file bundle (`.msg` + 4 attachments, one shared `001 -` sequence), created the `Archive` folder under the mailbox root, moved the mail into it and stamped the category. The reported `entry_id` is the post-move one.
- [x] `revert` on that same mail, immediately: all 5 files deleted, category removed, mail back in the Inbox. Confirmed independently over COM afterwards — mail present in the Inbox, `Categories` empty, `Archive` folder item count 0, no `001 - …` files left in the destination folder.
- [x] `find_by_message_id` verified on **both** paths against the live mailbox: the fast server-side `Restrict` and the linear fallback (forced by making `Find` raise) each found the same mail. The fallback reads only the Message-ID, never resolving senders through `GetExchangeUser` — the one call that can raise Outlook's address-book modal and hang the process.
- [x] Cannot-start paths: `--candidates 0`, a decisions file of the wrong shape, a missing items file (`bad_input`) and a **malformed `config.yaml`** (`config_missing`) each exit **2** with a JSON document on stdout and no traceback.
- [ ] **Not verified:** the `outlook_unavailable` timeout branch (Outlook started but never publishing its COM object). Reaching it would have meant deliberately breaking the user's live Outlook; it is covered by construction and by the bounded poll, not by a walk.

**Independent review** — a fresh agent with no memory of the build fetched the acceptance criteria itself, read the diff and re-ran the gate independently: **pass**. It confirmed every acceptance criterion against the code and its test, and raised two non-blocking observations — a malformed `config.yaml` tracebacking instead of emitting the error document, and a failed tag reported under `move_failed`. Both were fixed in this branch and re-reviewed by the same reviewer on the delta: **pass** again (gate re-run independently: 106 passed).

**Sanity sweep** — `git diff main...HEAD` read in full. No dependency bumps, no removed or weakened tests, no `.gitignore` edits. Two broad handlers, both deliberate and both documented inline: `_safe_com` (one COM property failing must degrade that field, not abort a run over the whole Inbox) and the `load_config` guard at the process boundary (anything that stops the config loading *is* a run that could not start, which is what exit 2 plus the error document means; `BaseException` still propagates). One in-file cleanup within the change's own scope: the pywintypes→datetime conversion in `get_selected_email` now goes through the shared `_sent_datetime` helper, which also fixes it to prefer `SentOn` over `ReceivedTime` — the same order `archiver._get_sent_date_prefix` already used, so a plan's date and a `YYYY-MM-DD -` prefix cannot disagree.

**Public-repo check** — the diff was grepped for real folder names, addresses, mail subjects and hostnames. Every fixture, test and doc string is synthetic (`example.invalid`, "Project Alpha"). Nothing from the real walk appears anywhere in the repo.

## Notes for the downstream consumer

- Every document carries `schema_version` (currently `1`) so a consumer can refuse a shape it does not understand.
- An `apply` document can be handed straight back to `revert` — an object with a `decisions` / `items` / `results` list is accepted as-is.
- Per-mail `error.code`: `bad_decision`, `not_in_inbox`, `not_in_archive_folder`, `archive_failed`, `move_failed`, `category_failed`. Run-level: `config_missing`, `bad_input`, `outlook_unavailable`, `com_unavailable`.
- `already_archived` is `null` for anything filed before this build — see the backfill note above. Do not read `null` as proof the mail was never archived.
- Spawn it with a timeout: a COM modal blocks *this* process, which the caller can kill, and never the caller.

Closes #53

https://claude.ai/code/session_01XY1TW3d8mm8YDZDLqjjEdd
