### PR TITLE
feat: infer the date-prefix filename form per destination folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,23 @@ The email's sent date can be prefixed to every name in the bundle, for folders s
 2026-03-14 - 023 - signed_contract.docx
 ```
 
-It is **off by default** and can be switched on two ways:
-
-- **Per archive** — the **Date prefix (YYYY-MM-DD)** checkbox in the archive dialog's bottom bar. Tick it before clicking `Archive`, `Browse folder…` or `Explorer folder`; it applies to that archive only and nothing is written to the config.
-- **Permanently** — `naming.date_prefix: true` in `config/config.yaml`. That sets the checkbox's starting position every time the dialog opens, so the per-archive checkbox can still override it in either direction.
+`naming.date_prefix` in `config/config.yaml` controls the default form:
 
 ```yaml
 naming:
-  date_prefix: false   # default; true → 2026-03-14 - 023 - subject.msg
+  date_prefix: auto   # default; true → always dated, false → never dated
 ```
+
+- **`auto` (default)** — infer the form per destination folder from what it already holds: majority of existing numbered files wins (dated vs. undated), falling back to the undated form when the folder is empty, has no numbered files, or ties. This is what makes an unattended batch run (see [Batch mode](#batch-mode-headless), which has no checkbox) file into a mixed archive correctly without any per-mail configuration — a folder that already files everything as `YYYY-MM-DD - NNN - <name>` (for instance a tree shared with a dated document archive) keeps getting the dated form, the rest keep the undated form.
+- **`true` / `false`** — force that form for every folder, ignoring its contents.
+- **Per archive** — the **Date prefix (YYYY-MM-DD)** checkbox in the archive dialog's bottom bar starts pre-ticked to whatever the highlighted suggestion's own folder would get (inferred when the config is `auto`, the fixed config value otherwise), and can still be flipped by hand before clicking `Archive`, `Browse folder…` or `Explorer folder`; nothing is written to the config either way.
+
+Precedence when a decision is not left to inference: an explicit per-archive choice (the ticked/unticked checkbox, or a batch `apply` decision's `date_prefix`) always wins over the config, `auto` inference is next, and the config's fixed boolean is the last resort.
 
 - `YYYY-MM-DD` is the email's **sent** date (`SentOn`, falling back to `ReceivedTime`), normalized to local time — not the date it was archived. Attachments inherit the parent email's date, so a bundle stays contiguous.
 - `NNN` keeps exactly the same meaning and derivation with the prefix on
 - If the email's sent date cannot be resolved, that archive falls back to the undated form and logs why, rather than inventing a placeholder date
-- Sequence allocation recognizes **both** the `NNN - ` and the `YYYY-MM-DD - NNN - ` forms no matter which one is being written, so a folder holding a mix of both still picks the correct next number and never collides — the toggle is safe to flip at any time
+- Sequence allocation recognizes **both** the `NNN - ` and the `YYYY-MM-DD - NNN - ` forms no matter which one is being written, so a folder holding a mix of both still picks the correct next number and never collides — the toggle is safe to flip at any time, and inference reads that same single folder listing
 - Path shortening accounts for the 13 extra characters only when the prefix is actually applied
 
 ---
@@ -191,7 +194,7 @@ archive:
     - "C:/Users/YourName/OneDrive/Archive/"
 ```
 
-All other defaults are sensible out of the box. The one knob worth knowing about is `naming.date_prefix` (default `false`) — see [File naming convention](#file-naming-convention).
+All other defaults are sensible out of the box. The one knob worth knowing about is `naming.date_prefix` (default `auto`) — see [File naming convention](#file-naming-convention).
 
 ### First scan
 
@@ -262,7 +265,7 @@ The project ships a pytest suite (`tests/`) covering the filename fitter, sequen
 
 | Verb | Reads | Does |
 |---|---|---|
-| `plan` | nothing | Starts Outlook if it is closed, enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10). Read-only. |
+| `plan` | nothing | Starts Outlook if it is closed, enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10), each carrying its own `date_prefix`. Read-only. |
 | `apply` | `[{message_id, folder_path, date_prefix}]` | Archives each mail into `folder_path`, then moves it to the Outlook `Archive` folder and tags it with the category. |
 | `revert` | `[{message_id, files}]` | Deletes exactly the listed files, removes the category and moves the mail back to the Inbox. |
 
@@ -291,7 +294,7 @@ Every document carries `schema_version`, so a consumer can refuse a shape it doe
 - A file already gone is reported as `missing`, not as an error — running a revert twice is not a failure to explain.
 - Outlook closed at `plan` time is **started** (the registered `outlook.exe`, visible, exactly as your own shortcut would) and waited for, bounded by `--start-timeout` (60 s by default). A still-unreachable Outlook is a loud exit 2, never an empty Inbox nobody read.
 - Batch mode is meant to be spawned with a timeout. A COM modal — the address-book security prompt, a profile chooser — then blocks *this* process, which the caller can kill, and never the caller.
-- The `date_prefix` flag is per mail and comes from the caller. Batch mode deliberately does **not** read the global `naming.date_prefix` toggle, because the right form depends on the destination folder.
+- The `date_prefix` flag on an `apply` decision is per mail and comes from the caller. Batch mode deliberately does **not** re-read the global `naming.date_prefix` toggle itself for `apply` — the right form depends on the destination folder, so each `plan` candidate already carries the `date_prefix` that folder would get under the configured mode (inferred per folder when `naming.date_prefix: auto`, the fixed config value otherwise); the caller normally just hands that value straight back on the decision for the folder it picked.
 
 ### Configuration
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -13,13 +13,17 @@ archive:
 
 naming:
   # Prepend the email's sent date to archived filenames.
-  #   false (default) → 023 - subject.msg
-  #   true            → 2026-03-14 - 023 - subject.msg
+  #   false            → 023 - subject.msg
+  #   true             → 2026-03-14 - 023 - subject.msg
+  #   auto (default)   → infer per destination folder from what it already
+  #                       holds (majority of existing numbered files wins;
+  #                       falls back to the undated form when the folder is
+  #                       empty, has no numbered files, or ties)
   # The NNN sequence is always present and always shared by an email and its
   # attachments. Sequence allocation reads both forms whichever way this is
   # set, so it is safe to flip at any time — a folder holding a mix of dated
   # and undated files still gets the correct next number.
-  date_prefix: false
+  date_prefix: auto
 
 outlook:
   # Batch mode only (main_batch.py). After `apply` has written a mail to disk

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -16,7 +16,7 @@ flowchart TB
     MAINBATCH["main_batch.py\nheadless plan / apply / revert,\none JSON document on stdout"]
   end
 
-  CONFIG["email_archiver/config.py\nload_config · get_archive_roots ·\nget_max_path_length · get_date_prefix_enabled ·\nget_outlook_archive_folder · get_outlook_category ·\nsetup_logging"]
+  CONFIG["email_archiver/config.py\nload_config · get_archive_roots ·\nget_max_path_length · get_date_prefix_mode/_enabled ·\nget_outlook_archive_folder · get_outlook_category ·\nsetup_logging"]
   TEXT["email_archiver/text.py\nclean_subject — shared Re:/Fwd: stripping ·\nnormalize_message_id — one spelling of the\nMessage-ID for the scanner and the Outlook client"]
 
   MAINSCAN --> CONFIG
@@ -60,7 +60,7 @@ flowchart TB
   subgraph archive["Archive Email data flow"]
     OUTLOOK["outlook/client.py: OutlookClient\nCOM isolation, SMTP resolution\n(GetExchangeUser fallback)"]
     SUGGESTER["engine/suggester.py: SuggestionEngine\n3-stage blend: 0.45 FTS + 0.30 subject-thread\n+ 0.25 folder-name (rapidfuzz)"]
-    ARCHIVER["archiver/archiver.py: EmailArchiver\nNNN - sequencing, optional YYYY-MM-DD prefix,\npath-length fit, SaveAs .msg + SaveAsFile attachments"]
+    ARCHIVER["archiver/archiver.py: EmailArchiver\nNNN - sequencing, YYYY-MM-DD prefix\n(forced or auto-inferred per folder),\npath-length fit, SaveAs .msg + SaveAsFile attachments"]
   end
   ARCHIVEDIALOG --> OUTLOOK
   OUTLOOK -->|win32com| OUTLOOKCOM["Outlook COM\n(running Outlook.exe process)"]

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -6,14 +6,21 @@ Naming convention (matches user spec):
     Attachments: NNN - filename.ext
 
 NNN is a zero-padded 3-digit sequence (000-999) shared by an email and its
-attachments. With ``naming.date_prefix: true`` in the config, the email's sent
-date in local time is prefixed as well:
+attachments. With the sent-date prefix in effect, the email's sent date in
+local time is prefixed as well:
 
     Email:       YYYY-MM-DD - NNN - sanitized_subject.msg
     Attachments: YYYY-MM-DD - NNN - filename.ext
 
-The toggle is off by default. When it is on but the sent date cannot be
-resolved, the undated form is used for that email instead.
+``naming.date_prefix`` in the config controls this per folder:
+    false (default) → never prefix
+    true            → always prefix
+    "auto"          → infer the form from what the destination folder
+                       already holds (see ``infer_date_prefix``), falling
+                       back to the undated form when inference is ambiguous
+
+Whichever form is chosen, if the sent date cannot be resolved the undated
+form is used for that email instead.
 
 Design decisions:
 - Sequence number is derived from the MAXIMUM existing numeric prefix in the
@@ -21,6 +28,8 @@ Design decisions:
   scan recognises both prefix forms regardless of the toggle, so a folder
   holding a mix of dated and undated files always allocates the next number
   correctly and the toggle stays safe to flip at any time.
+- ``infer_date_prefix`` shares that same listing pass (see ``_scan_folder``):
+  the archiver never lists a destination folder twice for one archive call.
 - Embedded images (ContentId set) are skipped; only real attachments are saved.
 - Subject sanitisation removes characters illegal on Windows file systems.
 - SaveAs uses olMSG format constant (3) to produce a proper .msg file.
@@ -36,9 +45,10 @@ from pathlib import Path
 from typing import Any
 
 from email_archiver.config import (
+    DATE_PREFIX_AUTO,
     DEFAULT_DATE_PREFIX_ENABLED,
     DEFAULT_MAX_PATH_LENGTH,
-    get_date_prefix_enabled,
+    get_date_prefix_mode,
     get_max_path_length,
 )
 
@@ -127,6 +137,57 @@ def _fit_filename_to_path(
     return f"{prefix}{stem[:stem_budget]}{suffix}"
 
 
+@dataclass
+class _FolderScan:
+    """The result of one ``os.listdir`` pass over a destination folder."""
+
+    next_sequence: str
+    inferred_date_prefix: bool | None
+
+
+def _scan_folder(folder_path: str) -> _FolderScan:
+    """
+    List ``folder_path`` once and derive both the next sequence number and
+    the per-folder date-prefix inference from that single pass.
+
+    This is the one place that actually calls ``os.listdir`` on a
+    destination folder — ``get_next_sequence_number`` and
+    ``infer_date_prefix`` are thin, independently-testable wrappers around
+    it, but ``EmailArchiver.archive`` calls this directly so a real archive
+    never lists a OneDrive-backed folder twice.
+    """
+    try:
+        files = os.listdir(folder_path)
+    except OSError as exc:
+        logger.error("Cannot list folder %s: %s", folder_path, exc)
+        return _FolderScan(next_sequence="001", inferred_date_prefix=None)
+
+    numbers: list[int] = []
+    dated = 0
+    undated = 0
+    for fname in files:
+        m = _RE_DATED_PREFIX.match(fname)
+        if m:
+            numbers.append(int(m.group(1)))
+            dated += 1
+            continue
+        m = _RE_UNDATED_PREFIX.match(fname)
+        if m:
+            numbers.append(int(m.group(1)))
+            undated += 1
+
+    next_num = (max(numbers) + 1) if numbers else 1
+    if next_num > 999:
+        logger.warning("Sequence number exceeds 999 in %s", folder_path)
+    next_sequence = f"{next_num:03d}"
+
+    # Empty/unnumbered (0 == 0) and a genuine tie both mean "no clear form" —
+    # neither is worth forcing a guess on, so both come out as None.
+    inferred: bool | None = None if dated == undated else dated > undated
+
+    return _FolderScan(next_sequence=next_sequence, inferred_date_prefix=inferred)
+
+
 def get_next_sequence_number(folder_path: str) -> str:
     """
     Scan the folder for files starting with either the undated ``NNN - `` or
@@ -135,22 +196,46 @@ def get_next_sequence_number(folder_path: str) -> str:
     writes, so a folder holding a mix never gets a colliding number.
     Returns '001' if the folder is empty or has no numbered files.
     """
-    try:
-        files = os.listdir(folder_path)
-    except OSError as exc:
-        logger.error("Cannot list folder %s: %s", folder_path, exc)
-        return "001"
+    return _scan_folder(folder_path).next_sequence
 
-    numbers: list[int] = []
-    for fname in files:
-        m = _RE_DATED_PREFIX.match(fname) or _RE_UNDATED_PREFIX.match(fname)
-        if m:
-            numbers.append(int(m.group(1)))
 
-    next_num = (max(numbers) + 1) if numbers else 1
-    if next_num > 999:
-        logger.warning("Sequence number exceeds 999 in %s", folder_path)
-    return f"{next_num:03d}"
+def infer_date_prefix(folder_path: str) -> bool | None:
+    """
+    Infer which filename form ``folder_path`` already uses, from the same
+    dated-vs-undated counts ``get_next_sequence_number`` derives.
+
+    Majority wins: ``True`` when more of the folder's existing numbered
+    files use the dated ``YYYY-MM-DD - NNN - `` form than the undated
+    ``NNN - `` form, ``False`` for the reverse. Returns ``None`` when the
+    folder is empty, has no numbered files, or the two forms tie — callers
+    fall back to the undated form in that case rather than guess.
+    """
+    return _scan_folder(folder_path).inferred_date_prefix
+
+
+def resolve_date_prefix_for_folder(cfg: dict[str, Any], folder_path: str) -> bool:
+    """
+    The date-prefix form ``EmailArchiver.archive`` would pick for
+    ``folder_path`` under ``cfg``, absent an explicit per-call override.
+
+    ``naming.date_prefix: auto`` infers from the folder's own contents,
+    falling back to ``False`` when inference is ambiguous; ``true``/``false``
+    apply uniformly regardless of the folder. Used by batch ``plan`` to
+    report each candidate's form so the caller can hand it straight back to
+    an ``apply`` decision.
+    """
+    mode = get_date_prefix_mode(cfg)
+    inferred = infer_date_prefix(folder_path) if mode == DATE_PREFIX_AUTO else None
+    return _resolve_date_prefix_mode(mode, inferred)
+
+
+def _resolve_date_prefix_mode(mode: bool | str, inferred: bool | None) -> bool:
+    """Shared by ``EmailArchiver`` and ``resolve_date_prefix_for_folder``:
+    ``"auto"`` uses ``inferred`` (``False`` when it is ``None``), otherwise
+    ``mode`` is already the plain boolean to use."""
+    if mode == DATE_PREFIX_AUTO:
+        return bool(inferred) if inferred is not None else False
+    return bool(mode)
 
 
 def _get_sent_date_prefix(mail_item: Any) -> str | None:
@@ -201,25 +286,27 @@ class EmailArchiver:
 
         ``cfg`` is the loaded config dict; the path budget is read from it via
         the shared ``get_max_path_length`` accessor so the archiver and scanner
-        honour the same ``path.max_length`` knob, and the sent-date prefix
-        toggle via ``get_date_prefix_enabled`` (``naming.date_prefix``). When
-        ``cfg`` is omitted the ``DEFAULT_*`` fallbacks are used.
+        honour the same ``path.max_length`` knob, and the sent-date prefix mode
+        via ``get_date_prefix_mode`` (``naming.date_prefix``: ``True``,
+        ``False`` or ``"auto"``). When ``cfg`` is omitted the ``DEFAULT_*``
+        fallbacks are used.
 
-        ``date_prefix`` overrides the configured toggle for this archiver only
-        — the archive dialog passes its checkbox state through here, so the
-        config value is the checkbox's *starting* position rather than the last
-        word. ``None`` (the default) means "use the config".
+        ``date_prefix`` overrides the configured mode for this archiver only
+        — the archive dialog passes its checkbox state through here, and batch
+        mode passes the caller's per-mail decision, so the config is only the
+        *starting* position, never the last word. ``None`` (the default) means
+        "use the config": ``auto`` then infers the form per destination folder
+        at ``archive()`` time, falling back to the undated form when
+        inference is ambiguous.
         """
         self._max_path: int = (
             get_max_path_length(cfg) if cfg is not None else DEFAULT_MAX_PATH_LENGTH
         )
-        self._date_prefix_enabled: bool
-        if date_prefix is not None:
-            self._date_prefix_enabled = date_prefix
-        elif cfg is not None:
-            self._date_prefix_enabled = get_date_prefix_enabled(cfg)
-        else:
-            self._date_prefix_enabled = DEFAULT_DATE_PREFIX_ENABLED
+        # Explicit override always wins over the config; None defers to it.
+        self._date_prefix_override: bool | None = date_prefix
+        self._date_prefix_mode: bool | str = (
+            get_date_prefix_mode(cfg) if cfg is not None else DEFAULT_DATE_PREFIX_ENABLED
+        )
 
     def archive(
         self,
@@ -243,9 +330,15 @@ class EmailArchiver:
             logger.info("Creating destination folder: %s", dest)
             dest.mkdir(parents=True, exist_ok=True)
 
-        seq = get_next_sequence_number(folder_path)
+        # One listing pass covers both the next sequence number and (when the
+        # config mode is "auto") the per-folder date-prefix inference.
+        scan = _scan_folder(folder_path)
+        seq = scan.next_sequence
+        date_prefix_enabled = self._resolve_date_prefix_enabled(
+            scan.inferred_date_prefix
+        )
         date_prefix = (
-            _get_sent_date_prefix(mail_item) if self._date_prefix_enabled else None
+            _get_sent_date_prefix(mail_item) if date_prefix_enabled else None
         )
         result = ArchiveResult(sequence_number=seq)
 
@@ -264,6 +357,15 @@ class EmailArchiver:
             seq, result.email_path, len(result.attachment_paths),
         )
         return result
+
+    def _resolve_date_prefix_enabled(self, inferred: bool | None) -> bool:
+        """Precedence for this call: explicit constructor override beats the
+        config outright; otherwise the config decides — ``"auto"`` via
+        ``inferred`` (already derived from this same destination folder by
+        ``archive``), a plain boolean applied as-is."""
+        if self._date_prefix_override is not None:
+            return self._date_prefix_override
+        return _resolve_date_prefix_mode(self._date_prefix_mode, inferred)
 
     # -------------------------------------------------- private helpers ----
 

--- a/email_archiver/batch.py
+++ b/email_archiver/batch.py
@@ -37,7 +37,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from email_archiver.archiver.archiver import EmailArchiver
+from email_archiver.archiver.archiver import EmailArchiver, resolve_date_prefix_for_folder
 from email_archiver.config import (
     get_archive_roots,
     get_outlook_archive_folder,
@@ -103,13 +103,32 @@ def _engine_for(cfg: dict[str, Any], candidates: int) -> SuggestionEngine:
     return SuggestionEngine(tuned)
 
 
-def _candidate_dict(suggestion: Any) -> dict[str, Any]:
+def _candidate_dict(
+    cfg: dict[str, Any], suggestion: Any, date_prefix_cache: dict[str, bool]
+) -> dict[str, Any]:
+    """A ranked candidate, plus the ``date_prefix`` form its own folder would
+    get under ``cfg`` — inferred per folder when ``naming.date_prefix`` is
+    ``"auto"``, otherwise the config's fixed boolean. The caller (task-os)
+    hands this straight back as the ``date_prefix`` on its ``apply``
+    decision for the folder it picks; see ``resolve_date_prefix_for_folder``.
+
+    ``date_prefix_cache`` is ``plan``'s own dict, keyed by folder path and
+    shared across every mail in the run: a handful of folders tend to be
+    everyone's top suggestion, so without it a full-Inbox plan would re-list
+    the same OneDrive-backed folder once per mail that suggests it — exactly
+    the redundant-listing cost the per-``archive()`` single-pass guarantee is
+    there to avoid, just reappearing one layer up.
+    """
+    folder_path = suggestion.folder_path
+    if folder_path not in date_prefix_cache:
+        date_prefix_cache[folder_path] = resolve_date_prefix_for_folder(cfg, folder_path)
     return {
-        "folder_path": suggestion.folder_path,
+        "folder_path": folder_path,
         "display_name": suggestion.display_name,
         "score": round(suggestion.score, 4),
         "match_count": suggestion.match_count,
         "sample_subjects": list(suggestion.sample_subjects),
+        "date_prefix": date_prefix_cache[folder_path],
     }
 
 
@@ -223,6 +242,8 @@ def plan(
     mails: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     already = 0
+    # Shared across every mail in this run — see _candidate_dict.
+    date_prefix_cache: dict[str, bool] = {}
 
     try:
         for mail in client.iter_inbox(preview_len):
@@ -242,7 +263,7 @@ def plan(
                 entry["candidates"] = []
             else:
                 entry["candidates"] = [
-                    _candidate_dict(s)
+                    _candidate_dict(cfg, s, date_prefix_cache)
                     for s in engine.suggest(EmailData(
                         subject=mail.subject,
                         sender=mail.sender,

--- a/email_archiver/config.py
+++ b/email_archiver/config.py
@@ -27,8 +27,13 @@ DEFAULT_MAX_PATH_LENGTH = 255
 # Archived filenames carry the sequence prefix only (``NNN - name.ext``) unless
 # the sent-date prefix is explicitly switched on. Off by default: the shorter
 # form leaves more MAX_PATH headroom in deep folders, and the date is already
-# inside the .msg. See ``get_date_prefix_enabled``.
+# inside the .msg. See ``get_date_prefix_mode`` / ``get_date_prefix_enabled``.
 DEFAULT_DATE_PREFIX_ENABLED = False
+
+# The third ``naming.date_prefix`` value (alongside ``true``/``false``): infer
+# the form per destination folder from what it already holds. See
+# ``email_archiver.archiver.archiver.infer_date_prefix``.
+DATE_PREFIX_AUTO = "auto"
 
 # Where batch `apply` parks a mail once it is on disk, and the category it
 # stamps on it. The folder is looked up by name directly under the mailbox's
@@ -92,21 +97,41 @@ def get_max_path_length(cfg: dict[str, Any]) -> int:
     return int(value)
 
 
-def get_date_prefix_enabled(cfg: dict[str, Any]) -> bool:
-    """Return whether archived filenames get the email's sent date prefixed.
+def get_date_prefix_mode(cfg: dict[str, Any]) -> bool | str:
+    """Return the raw ``naming.date_prefix`` setting: ``True``, ``False``, or
+    the literal ``"auto"`` (case-insensitive in the YAML, normalised here).
 
-    Reads ``naming.date_prefix``, falling back to
-    ``DEFAULT_DATE_PREFIX_ENABLED`` (``False``) when the section or key is
-    absent, so a ``config.yaml`` written before the toggle existed keeps the
-    default sequence-only naming. Like ``get_max_path_length``, this is the one
-    place the key is read — the archiver goes through it rather than reaching
-    into the config dict itself.
+    Falls back to ``DEFAULT_DATE_PREFIX_ENABLED`` (``False``) when the
+    section or key is absent, so a ``config.yaml`` written before the toggle
+    existed keeps the default sequence-only naming. This is the one place
+    the raw key is read — the archiver goes through it (or the narrower
+    ``get_date_prefix_enabled`` below) rather than reaching into the config
+    dict itself. ``"auto"`` means "infer per destination folder"; resolving
+    that inference is the archiver's job, not this accessor's.
     """
     naming_cfg = cfg.get("naming") or {}
     value = naming_cfg.get("date_prefix")
     if value is None:
         return DEFAULT_DATE_PREFIX_ENABLED
+    if isinstance(value, str) and value.strip().lower() == DATE_PREFIX_AUTO:
+        return DATE_PREFIX_AUTO
     return bool(value)
+
+
+def get_date_prefix_enabled(cfg: dict[str, Any]) -> bool:
+    """Return whether archived filenames get the email's sent date prefixed,
+    as a plain boolean starting position — ``"auto"`` resolves to ``False``
+    here since no destination folder is known yet.
+
+    Used where only a boolean makes sense (the dialog checkbox's initial
+    position before any suggestion is highlighted); a caller that needs to
+    honour ``"auto"`` by inferring from a folder should use
+    ``get_date_prefix_mode`` together with
+    ``email_archiver.archiver.archiver.resolve_date_prefix_for_folder``
+    instead.
+    """
+    mode = get_date_prefix_mode(cfg)
+    return mode if isinstance(mode, bool) else False
 
 
 def get_outlook_archive_folder(cfg: dict[str, Any]) -> str:

--- a/email_archiver/ui/app.py
+++ b/email_archiver/ui/app.py
@@ -20,7 +20,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Any
 
-from email_archiver.archiver.archiver import EmailArchiver
+from email_archiver.archiver.archiver import EmailArchiver, resolve_date_prefix_for_folder
 from email_archiver.config import get_archive_roots, get_date_prefix_enabled
 from email_archiver.engine.suggester import RankedSuggestion, SuggestionEngine
 from email_archiver.explorer import (
@@ -305,6 +305,31 @@ class ArchiveDialog:
             ).pack()
 
             card.columnconfigure(1, weight=1)
+
+            # Highlighting a suggestion (mouse over its card) pre-ticks the
+            # date-prefix checkbox to the form that folder already uses — see
+            # _on_suggestion_highlighted. Bound on every descendant too, since
+            # <Enter> only fires on the exact widget the pointer is over, not
+            # its ancestors; the card is built by now so this walks the whole
+            # tree of children just created above.
+            self._bind_highlight(card, s.folder_path)
+
+    def _bind_highlight(self, widget: tk.Widget, folder_path: str) -> None:
+        widget.bind(
+            "<Enter>", lambda _e, fp=folder_path: self._on_suggestion_highlighted(fp)
+        )
+        for child in widget.winfo_children():
+            self._bind_highlight(child, folder_path)
+
+    def _on_suggestion_highlighted(self, folder_path: str) -> None:
+        """Pre-tick (or untick) the date-prefix checkbox to the form
+        ``folder_path`` would actually get, per ``naming.date_prefix`` —
+        inferred from the folder's own contents when the config is
+        ``"auto"``, the config's fixed boolean otherwise. The user can still
+        override it by hand before clicking Archive."""
+        self._date_prefix_var.set(
+            resolve_date_prefix_for_folder(self._cfg, folder_path)
+        )
 
     def _show_error(self, msg: str) -> None:
         for w in self._suggestions_frame.winfo_children():

--- a/tests/test_archiver_date_prefix_toggle.py
+++ b/tests/test_archiver_date_prefix_toggle.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
-from email_archiver.archiver.archiver import EmailArchiver
-from email_archiver.config import get_date_prefix_enabled
+from email_archiver.archiver.archiver import EmailArchiver, resolve_date_prefix_for_folder
+from email_archiver.config import get_date_prefix_enabled, get_date_prefix_mode
 
 
 class _FakeAttachment:
@@ -70,6 +70,22 @@ def test_explicit_true_is_on():
 
 def test_explicit_false_is_off():
     assert get_date_prefix_enabled({"naming": {"date_prefix": False}}) is False
+
+
+def test_mode_returns_true_false_or_auto():
+    assert get_date_prefix_mode({}) is False
+    assert get_date_prefix_mode({"naming": {"date_prefix": True}}) is True
+    assert get_date_prefix_mode({"naming": {"date_prefix": False}}) is False
+    assert get_date_prefix_mode({"naming": {"date_prefix": "auto"}}) == "auto"
+    # Case-insensitive, since it comes from hand-edited YAML.
+    assert get_date_prefix_mode({"naming": {"date_prefix": "AUTO"}}) == "auto"
+
+
+def test_enabled_resolves_auto_to_false():
+    # get_date_prefix_enabled has no folder to infer from, so "auto" is a
+    # starting position of False — the UI resolves the real value per
+    # suggestion via resolve_date_prefix_for_folder instead.
+    assert get_date_prefix_enabled({"naming": {"date_prefix": "auto"}}) is False
 
 
 # ------------------------------------------------------------- archiving ----
@@ -187,3 +203,95 @@ def test_toggle_on_still_continues_an_undated_folders_sequence(tmp_path):
         _FakeMailItem(), str(tmp_path), "Next one"
     )
     assert result.email_path.endswith("2026-03-14 - 013 - Next one.msg")
+
+
+# --------------------------------------------------- naming.date_prefix: auto ----
+
+def test_auto_writes_the_dated_form_into_an_already_dated_folder(tmp_path):
+    # Acceptance criterion: auto writes the dated form with no checkbox/
+    # explicit-argument interaction at all — the config alone decides.
+    (tmp_path / "2026-01-01 - 001 - earlier.msg").write_text("x")
+    (tmp_path / "2026-01-02 - 002 - earlier2.msg").write_text("x")
+    result = EmailArchiver(_cfg(date_prefix="auto")).archive(
+        _FakeMailItem(), str(tmp_path), "Next one"
+    )
+    assert result.email_path.endswith("2026-03-14 - 003 - Next one.msg")
+
+
+def test_auto_writes_the_undated_form_into_an_already_undated_folder(tmp_path):
+    (tmp_path / "001 - earlier.msg").write_text("x")
+    result = EmailArchiver(_cfg(date_prefix="auto")).archive(
+        _FakeMailItem(), str(tmp_path), "Next one"
+    )
+    assert result.email_path.endswith("002 - Next one.msg")
+
+
+def test_auto_falls_back_to_undated_on_an_empty_folder(tmp_path):
+    result = EmailArchiver(_cfg(date_prefix="auto")).archive(
+        _FakeMailItem(), str(tmp_path), "First one"
+    )
+    assert result.email_path.endswith("001 - First one.msg")
+
+
+def test_auto_falls_back_to_undated_on_a_tied_folder(tmp_path):
+    (tmp_path / "001 - a.msg").write_text("x")
+    (tmp_path / "2026-01-01 - 002 - b.msg").write_text("x")
+    result = EmailArchiver(_cfg(date_prefix="auto")).archive(
+        _FakeMailItem(), str(tmp_path), "Next one"
+    )
+    assert result.email_path.endswith("003 - Next one.msg")
+
+
+# --------------------------------------------------------------- precedence ----
+# explicit constructor override > config "auto" (per-folder inference) >
+# config boolean.
+
+def test_explicit_override_beats_auto_inference(tmp_path):
+    (tmp_path / "2026-01-01 - 001 - earlier.msg").write_text("x")
+    # Folder is majority-dated, but the explicit override says no prefix.
+    result = EmailArchiver(_cfg(date_prefix="auto"), date_prefix=False).archive(
+        _FakeMailItem(), str(tmp_path), "Overridden"
+    )
+    assert result.email_path.endswith("002 - Overridden.msg")
+
+
+def test_explicit_override_true_beats_auto_inference_toward_dated(tmp_path):
+    (tmp_path / "001 - earlier.msg").write_text("x")
+    # Folder is majority-undated, but the explicit override forces the date.
+    result = EmailArchiver(_cfg(date_prefix="auto"), date_prefix=True).archive(
+        _FakeMailItem(), str(tmp_path), "Overridden"
+    )
+    assert result.email_path.endswith("2026-03-14 - 002 - Overridden.msg")
+
+
+def test_auto_beats_the_config_boolean_it_replaces(tmp_path):
+    # Sanity check on precedence order, not just presence: "auto" governs
+    # once selected, the (now-irrelevant) DEFAULT_DATE_PREFIX_ENABLED value
+    # never leaks in as a silent third form.
+    (tmp_path / "2026-01-01 - 001 - earlier.msg").write_text("x")
+    result = EmailArchiver(_cfg(date_prefix="auto")).archive(
+        _FakeMailItem(), str(tmp_path), "Next one"
+    )
+    assert "2026-03-14" in result.email_path
+
+
+# ---------------------------------------------- resolve_date_prefix_for_folder ----
+# The dialog (hover pre-tick) and batch plan (per-candidate date_prefix) both
+# go through this to answer "what would EmailArchiver pick for this folder,
+# absent an explicit override" without constructing an EmailArchiver at all.
+
+def test_resolve_for_folder_infers_in_auto_mode(tmp_path):
+    (tmp_path / "2026-01-01 - 001 - a.msg").write_text("x")
+    (tmp_path / "2026-01-02 - 002 - b.msg").write_text("x")
+    assert resolve_date_prefix_for_folder(_cfg(date_prefix="auto"), str(tmp_path)) is True
+
+
+def test_resolve_for_folder_falls_back_to_false_on_ambiguous_auto(tmp_path):
+    assert resolve_date_prefix_for_folder(_cfg(date_prefix="auto"), str(tmp_path)) is False
+
+
+def test_resolve_for_folder_ignores_folder_contents_when_not_auto(tmp_path):
+    (tmp_path / "2026-01-01 - 001 - a.msg").write_text("x")
+    (tmp_path / "2026-01-02 - 002 - b.msg").write_text("x")
+    # Folder is majority-dated, but the config forces the undated form.
+    assert resolve_date_prefix_for_folder(_cfg(date_prefix=False), str(tmp_path)) is False

--- a/tests/test_archiver_sequencing.py
+++ b/tests/test_archiver_sequencing.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from email_archiver.archiver.archiver import (
     _get_sent_date_prefix,
     get_next_sequence_number,
+    infer_date_prefix,
 )
 
 
@@ -57,6 +58,42 @@ def test_dated_prefix_year_is_not_mistaken_for_sequence(tmp_path):
     # as the sequence number. It must not.
     (tmp_path / "2026-03-14 - 001 - only_file.msg").write_text("x")
     assert get_next_sequence_number(str(tmp_path)) == "002"
+
+
+# ---------------------------------------------------------------- infer_date_prefix ---
+
+def test_infer_date_prefix_none_on_empty_folder(tmp_path):
+    assert infer_date_prefix(str(tmp_path)) is None
+
+
+def test_infer_date_prefix_none_when_folder_has_no_numbered_files(tmp_path):
+    (tmp_path / "notes.txt").write_text("x")
+    (tmp_path / "random file.msg").write_text("x")
+    assert infer_date_prefix(str(tmp_path)) is None
+
+
+def test_infer_date_prefix_true_for_majority_dated_folder(tmp_path):
+    (tmp_path / "2026-01-01 - 001 - a.msg").write_text("x")
+    (tmp_path / "2026-01-02 - 002 - b.msg").write_text("x")
+    (tmp_path / "003 - c.msg").write_text("x")
+    assert infer_date_prefix(str(tmp_path)) is True
+
+
+def test_infer_date_prefix_false_for_majority_undated_folder(tmp_path):
+    (tmp_path / "001 - a.msg").write_text("x")
+    (tmp_path / "002 - b.msg").write_text("x")
+    (tmp_path / "2026-01-01 - 003 - c.msg").write_text("x")
+    assert infer_date_prefix(str(tmp_path)) is False
+
+
+def test_infer_date_prefix_none_on_a_tie(tmp_path):
+    (tmp_path / "001 - a.msg").write_text("x")
+    (tmp_path / "2026-01-01 - 002 - b.msg").write_text("x")
+    assert infer_date_prefix(str(tmp_path)) is None
+
+
+def test_infer_date_prefix_none_when_folder_does_not_exist(tmp_path):
+    assert infer_date_prefix(str(tmp_path / "does-not-exist")) is None
 
 
 # ------------------------------------------------------------- _get_sent_date_prefix ---

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -19,12 +19,14 @@ Everything on screen here is synthetic: no real folder name, address or subject.
 """
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 
 from email_archiver import batch
+from email_archiver.archiver import archiver as archiver_module
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
 from email_archiver.outlook.client import (
@@ -248,8 +250,80 @@ def test_plan_lists_every_inbox_mail_with_ranked_candidates(cfg, archive_root):
     assert first["candidates"], "a seeded index must produce candidates"
     assert set(first["candidates"][0]) == {
         "folder_path", "display_name", "score", "match_count", "sample_subjects",
+        "date_prefix",
     }
     assert first["candidates"][0]["folder_path"] == str(archive_root / "Project Alpha")
+    # cfg's naming.date_prefix is False (not "auto"), so every candidate gets
+    # the fixed config value regardless of what its folder holds.
+    assert first["candidates"][0]["date_prefix"] is False
+
+
+def test_plan_infers_date_prefix_per_candidate_folder_in_auto_mode(cfg, archive_root):
+    """naming.date_prefix: auto — each candidate's date_prefix reflects what
+    its own folder already holds, not one fixed value for every candidate."""
+    cfg["naming"]["date_prefix"] = "auto"
+    _seed_index(cfg, archive_root, {
+        "Project Alpha": ["Project Alpha kickoff"],
+        "Project Beta": ["Project Beta retro"],
+    })
+    dated_folder = archive_root / "Project Alpha"
+    undated_folder = archive_root / "Project Beta"
+    dated_folder.mkdir(parents=True, exist_ok=True)
+    undated_folder.mkdir(parents=True, exist_ok=True)
+    (dated_folder / "2026-01-01 - 001 - a.msg").write_text("x")
+    (dated_folder / "2026-01-02 - 002 - b.msg").write_text("x")
+    (undated_folder / "001 - a.msg").write_text("x")
+    (undated_folder / "002 - b.msg").write_text("x")
+
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "Project Alpha weekly update"),
+        _mail("b@example.invalid", "Project Beta retro follow-up"),
+    ])
+    doc = batch.plan(client, cfg, candidates=5)
+
+    by_folder = {
+        c["folder_path"]: c["date_prefix"]
+        for m in doc["mails"] for c in m["candidates"]
+    }
+    assert by_folder[str(dated_folder)] is True
+    assert by_folder[str(undated_folder)] is False
+
+
+def test_plan_lists_a_shared_candidate_folder_only_once_per_run(
+    cfg, archive_root, monkeypatch
+):
+    """A folder that two different mails both suggest must only be listed
+    once for the whole plan() run, not once per mail that suggests it — a
+    full-Inbox plan has a handful of popular folders and many mails, so an
+    uncached per-candidate os.listdir would re-list the same OneDrive-backed
+    folder over and over (the caching in _candidate_dict's date_prefix_cache
+    exists to prevent exactly that)."""
+    cfg["naming"]["date_prefix"] = "auto"
+    _seed_index(cfg, archive_root, {"Project Alpha": ["Project Alpha kickoff"]})
+    folder = archive_root / "Project Alpha"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "2026-01-01 - 001 - a.msg").write_text("x")
+
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "Project Alpha weekly update"),
+        _mail("b@example.invalid", "Project Alpha budget question"),
+    ])
+
+    real_listdir = os.listdir
+    calls: list[str] = []
+
+    def _counting_listdir(path):
+        calls.append(str(path))
+        return real_listdir(path)
+
+    monkeypatch.setattr(archiver_module.os, "listdir", _counting_listdir)
+
+    doc = batch.plan(client, cfg, candidates=1)
+
+    assert [m["candidates"][0]["folder_path"] for m in doc["mails"]] == [
+        str(folder), str(folder),
+    ]
+    assert calls.count(str(folder)) == 1
 
 
 def test_plan_honours_the_candidate_cap_not_the_config(cfg, archive_root):


### PR DESCRIPTION
## Summary

Replaces the single global `naming.date_prefix` toggle with a per-folder decision. Some archive trees already file everything as `YYYY-MM-DD - NNN - <name>` (shared with a dated document archive); the rest use plain `NNN - <name>`. Previously the user had to remember to tick the dialog checkbox for the dated trees, and the headless batch mode (#53) had no checkbox at all — so an unattended run needed the destination folder itself to say which form it uses.

`naming.date_prefix` now accepts a third value, `auto` (the new example-config default): `infer_date_prefix(folder_path)` counts the folder's existing dated-vs-undated numbered files in the same `os.listdir` pass `get_next_sequence_number` already does (`_scan_folder`), majority wins, and it falls back to the undated form on an empty, unnumbered, or tied folder rather than guess. `true`/`false` keep forcing one form unconditionally, as before.

- `EmailArchiver.archive()` resolves the effective form per call with precedence **explicit override > config `auto` (inferred from the destination) > config boolean** — one listing pass per archive, same as today.
- The archive dialog's checkbox now pre-ticks to whatever the highlighted suggestion's own folder would get (`resolve_date_prefix_for_folder`), and stays overridable by hand before clicking Archive/Browse/Explorer-folder.
- Batch `plan` reports each candidate's `date_prefix` (via the same `resolve_date_prefix_for_folder`) so the consumer (task-os, ferraroroberto/task-os#157) can hand it straight back on an `apply` decision — cached per folder for the whole `plan()` run, since a handful of folders tend to be everyone's top suggestion and an uncached per-candidate `os.listdir` would re-list the same OneDrive-backed folder over and over across a full-Inbox run.

## Validation

**Automated gate** (this repo's declared gate is `pytest`; no linter is configured, so none was run and none is claimed)

- [x] `& .\.venv\Scripts\python.exe -m pytest tests/` — **126 passed** (125 before this branch, 1 new since a follow-up fix landed after the first green run)
- [x] `& .\.venv\Scripts\python.exe -m py_compile` on every changed module — exit 0
- [x] New tests cover the three `infer_date_prefix` outcomes (majority-dated, majority-undated, empty/unnumbered/tie), the `auto` config end to end through `EmailArchiver.archive`, and the precedence chain (explicit override beats `auto` in both directions, `auto` beats the config boolean it replaces)
- [x] Batch `plan` tests cover a candidate's `date_prefix` under a fixed config value, under `auto` with real dated/undated folders on disk, and — added after an independent review flagged the uncached-`os.listdir`-per-candidate cost — a regression test proving a folder two different mails both suggest is listed only once per `plan()` run. That regression test was proven to fail (2 listings, not 1) against the pre-fix code before the caching fix was restored.

**Real-Outlook walk** (read-only, no `apply`, per this branch's constraint on not archiving real mail)

- [x] `main_batch.py --start-timeout 60 plan --candidates 3` against the live Inbox: exit 0, 7 mails, 21 candidates, every candidate carries a `date_prefix` boolean, key set matches the documented shape. The local `config.yaml` has `naming.date_prefix: false` (not `auto`), so all 21 came back `False` — confirms the fixed-boolean path is live end to end; the `auto`-inference path is proven by the unit tests listed above, not by this real walk (the local config wasn't changed for this verification, deliberately, to avoid touching real archiving behavior).

**Dialog checkbox behaviour** — verified by reading the code path, not a headed walk (optional per this issue): the hover binding (`_bind_highlight`) is wired after all of a suggestion card's child widgets exist, recurses over the whole subtree, and calls the same `resolve_date_prefix_for_folder` the batch-plan path uses and the unit tests cover directly.

**Independent review** — a fresh agent with no memory of the build read the issue, the diff, and the code paths cold, and re-ran the gate independently (125 passed at that point): **pass**. It confirmed every acceptance criterion against the code and flagged one non-blocking finding — `plan`'s per-candidate `date_prefix` does an uncached `os.listdir` per candidate, which could re-list the same popular folder many times across a full-Inbox run. Fixed in this branch (the per-run cache above) and covered by the new regression test rather than deferred.

**Public-repo check** — every test, fixture, README and config-example line uses synthetic data (`Project Alpha`/`Project Beta`, `example.invalid`); nothing from the real read-only walk (folder names, subjects, addresses) appears anywhere in the diff.

## Notes for the downstream consumer

- A `plan` candidate's `date_prefix` field is a plain boolean (never `null`): `True`/`False` under `auto` is already resolved via inference-with-fallback, and under a fixed config value it's that value regardless of the folder. Hand it straight back as the `date_prefix` on an `apply` decision for the folder you pick.

Closes #54

https://claude.ai/code/session_01XY1TW3d8mm8YDZDLqjjEdd