### PR TITLE
fix: revert now removes the index row for each deleted .msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The project ships a pytest suite (`tests/`) covering the filename fitter, sequen
 |---|---|---|
 | `plan` | nothing | Starts Outlook if it is closed, enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10), each carrying its own `date_prefix`. Read-only. |
 | `apply` | `[{message_id, folder_path, date_prefix}]` | Archives each mail into `folder_path`, then moves it to the Outlook `Archive` folder and tags it with the category. |
-| `revert` | `[{message_id, files}]` | Deletes exactly the listed files, removes the category and moves the mail back to the Inbox. |
+| `revert` | `[{message_id, files}]` | Deletes exactly the listed files, removes their index rows, removes the category and moves the mail back to the Inbox. |
 
 An `apply` result can be handed straight back to `revert` — the object with its `results` list is accepted as-is, no reshaping needed.
 
@@ -292,6 +292,7 @@ Every document carries `schema_version`, so a consumer can refuse a shape it doe
 
 - `revert` deletes **only** the files it is given, and only those that resolve inside `archive.root_paths`. Anything else is refused per file with a reason (`outside_archive_roots`, `unresolvable_path`) and left on disk.
 - A file already gone is reported as `missing`, not as an error — running a revert twice is not a failure to explain.
+- Deleting a `.msg` also removes its row from the index in the same step (`index_rows_removed` in the result), so `plan` offers the mail again right away instead of waiting for the next full scan to notice the file is gone. A file whose delete failed keeps its row — the file is still there, so the row is still correct.
 - Outlook closed at `plan` time is **started** (the registered `outlook.exe`, visible, exactly as your own shortcut would) and waited for, bounded by `--start-timeout` (60 s by default). A still-unreachable Outlook is a loud exit 2, never an empty Inbox nobody read.
 - Batch mode is meant to be spawned with a timeout. A COM modal — the address-book security prompt, a profile chooser — then blocks *this* process, which the caller can kill, and never the caller.
 - The `date_prefix` flag on an `apply` decision is per mail and comes from the caller. Batch mode deliberately does **not** re-read the global `naming.date_prefix` toggle itself for `apply` — the right form depends on the destination folder, so each `plan` candidate already carries the `date_prefix` that folder would get under the configured mode (inferred per folder when `naming.date_prefix: auto`, the fixed config value otherwise); the caller normally just hands that value straight back on the decision for the folder it picked.

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -84,3 +84,4 @@ flowchart TB
   BATCH -->|plan: already archived?| REPO
   BATCH -->|apply: per-mail date_prefix| ARCHIVER
   BATCH -->|revert: delete only inside archive.root_paths| ONEDRIVE
+  BATCH -->|revert: delete_by_path per deleted .msg| REPO

--- a/email_archiver/batch.py
+++ b/email_archiver/batch.py
@@ -435,6 +435,7 @@ def _blank_revert_result(message_id: str) -> dict[str, Any]:
         "moved_back": False,
         "category_removed": False,
         "entry_id": "",
+        "index_rows_removed": 0,
         "error": None,
     }
 
@@ -455,73 +456,49 @@ def revert(
     (gone now), ``missing`` (already gone — not an error, a revert run twice),
     ``refused`` (policy said no) and ``file_errors`` (the delete was attempted
     and the OS said no).
+
+    Deleting a ``.msg`` also removes its index row in the same step (via
+    ``EmailRepository.delete_by_path``, next to ``delete_missing_emails``'s
+    end-of-scan sweep): otherwise the row survives until the next full scan,
+    and ``plan`` in between reports the mail ``already_archived`` at a path
+    that no longer exists instead of offering it again. A file whose delete
+    failed leaves its row alone — the file is still there, so the row is
+    still correct. Reported per result as ``index_rows_removed``.
     """
     archive_folder = get_outlook_archive_folder(cfg)
     category = get_outlook_category(cfg)
     roots = _archive_roots(cfg)
     results: list[dict[str, Any]] = []
 
-    for raw in items:
-        message_id = normalize_message_id(raw.get("message_id"))
-        result = _blank_revert_result(message_id)
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    try:
+        for raw in items:
+            message_id = normalize_message_id(raw.get("message_id"))
+            result = _blank_revert_result(message_id)
 
-        for raw_path in raw.get("files") or []:
-            resolved, refusal = _resolve_under_roots(str(raw_path), roots)
-            if resolved is None:
-                result["refused"].append({"path": str(raw_path), "reason": refusal})
-                continue
-            try:
-                resolved.unlink()
-                result["deleted"].append(str(resolved))
-            except FileNotFoundError:
-                result["missing"].append(str(resolved))
-            except OSError as exc:
-                result["file_errors"].append(
-                    {"path": str(resolved), "message": f"{type(exc).__name__}: {exc}"}
-                )
+            for raw_path in raw.get("files") or []:
+                resolved, refusal = _resolve_under_roots(str(raw_path), roots)
+                if resolved is None:
+                    result["refused"].append({"path": str(raw_path), "reason": refusal})
+                    continue
+                try:
+                    resolved.unlink()
+                    result["deleted"].append(str(resolved))
+                except FileNotFoundError:
+                    result["missing"].append(str(resolved))
+                except OSError as exc:
+                    result["file_errors"].append(
+                        {"path": str(resolved), "message": f"{type(exc).__name__}: {exc}"}
+                    )
+                    continue
+                if resolved.suffix.lower() == ".msg":
+                    result["index_rows_removed"] += repo.delete_by_path(str(resolved))
+            conn.commit()
 
-        if not message_id:
-            result["error"] = {
-                "code": ERROR_BAD_DECISION,
-                "message": "an item needs a message_id to move the mail back",
-            }
-            results.append(result)
-            continue
-
-        try:
-            item = client.find_by_message_id(message_id, archive_folder)
-        except Exception as exc:
-            item = None
-            logger.warning("Archive-folder lookup for %s failed: %s", message_id, exc)
-
-        if item is None:
-            result["error"] = {
-                "code": ERROR_NOT_IN_ARCHIVE,
-                "message": (
-                    f"no mail with this Message-ID is in {archive_folder!r}; "
-                    "the files listed above were still processed"
-                ),
-            }
-            results.append(result)
-            continue
-
-        try:
-            client.clear_category(item, category)
-            result["category_removed"] = True
-            moved = client.move_to(item, None)
-            result["moved_back"] = True
-            result["entry_id"] = client.entry_id(moved)
-        except Exception as exc:
-            logger.exception("Moving %s back to the Inbox failed", message_id)
-            result["error"] = {
-                "code": ERROR_MOVE_FAILED,
-                "message": f"{type(exc).__name__}: {exc}",
-            }
-            results.append(result)
-            continue
-
-        result["ok"] = not result["refused"] and not result["file_errors"]
-        results.append(result)
+            results.append(_finish_revert_item(client, archive_folder, category, result, message_id))
+    finally:
+        conn.close()
 
     doc = _envelope("revert", cfg)
     reverted = sum(1 for r in results if r["ok"])
@@ -533,3 +510,52 @@ def revert(
     doc["results"] = results
     logger.info("Revert: %d of %d mail(s) restored.", reverted, len(results))
     return doc
+
+
+def _finish_revert_item(
+    client: Any,
+    archive_folder: str,
+    category: str,
+    result: dict[str, Any],
+    message_id: str,
+) -> dict[str, Any]:
+    """The Outlook side of one ``revert`` item, after its files are handled."""
+    if not message_id:
+        result["error"] = {
+            "code": ERROR_BAD_DECISION,
+            "message": "an item needs a message_id to move the mail back",
+        }
+        return result
+
+    try:
+        item = client.find_by_message_id(message_id, archive_folder)
+    except Exception as exc:
+        item = None
+        logger.warning("Archive-folder lookup for %s failed: %s", message_id, exc)
+
+    if item is None:
+        result["error"] = {
+            "code": ERROR_NOT_IN_ARCHIVE,
+            "message": (
+                f"no mail with this Message-ID is in {archive_folder!r}; "
+                "the files listed above were still processed"
+            ),
+        }
+        return result
+
+    try:
+        client.clear_category(item, category)
+        result["category_removed"] = True
+        moved = client.move_to(item, None)
+        result["moved_back"] = True
+        result["entry_id"] = client.entry_id(moved)
+    except Exception as exc:
+        logger.exception("Moving %s back to the Inbox failed", message_id)
+        result["error"] = {
+            "code": ERROR_MOVE_FAILED,
+            "message": f"{type(exc).__name__}: {exc}",
+        }
+        return result
+
+    result["ok"] = not result["refused"] and not result["file_errors"]
+    return result

--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -155,6 +155,16 @@ class EmailRepository:
         self._conn.execute("DROP TABLE tmp_known_paths")
         return cur.rowcount
 
+    def delete_by_path(self, file_path: str) -> int:
+        """Remove the index row for one file, if any. Returns rows deleted.
+
+        Called by ``batch.revert`` right after it unlinks a ``.msg`` it
+        deleted, so the index and the disk agree without waiting for the
+        next full scan's :meth:`delete_missing_emails` sweep. Caller commits.
+        """
+        cur = self._conn.execute("DELETE FROM emails WHERE file_path = ?", (file_path,))
+        return cur.rowcount
+
     # -------------------------------------------------- read operations ----
 
     def get_mtime(self, file_path: str) -> float | None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -578,6 +578,7 @@ def test_revert_deletes_the_files_and_puts_the_mail_back(cfg, archive_root):
     assert set(result) == {
         "message_id", "ok", "deleted", "missing", "refused", "file_errors",
         "moved_back", "category_removed", "entry_id", "error",
+        "index_rows_removed",
     }
     assert result["ok"] is True
     assert sorted(result["deleted"]) == sorted(str(Path(p)) for p in applied["files"])
@@ -587,6 +588,116 @@ def test_revert_deletes_the_files_and_puts_the_mail_back(cfg, archive_root):
     assert client.folders[None] == [item]
     assert client.folders["Archive"] == []
     assert item.Categories == ""
+    # No row was ever indexed for this mail (no scan ran), so there is
+    # nothing to remove -- this is not the stale-index regression below.
+    assert result["index_rows_removed"] == 0
+
+
+def _index_archived_file(cfg, applied, message_id="a@example.invalid", subject=""):
+    """Simulate the scan that normally indexes a freshly archived file.
+
+    ``apply`` only writes the file to disk -- ``main_scan.py`` is what
+    populates the index. The stale-row regression this guards only shows up
+    once a row exists, so the test has to write one by hand rather than rely
+    on ``apply`` to have done it.
+    """
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    file_path = applied["files"][0]
+    repo.upsert_email(EmailRecord(
+        file_path=file_path,
+        folder_path=str(Path(file_path).parent),
+        filename=Path(file_path).name,
+        subject=subject,
+        message_id=message_id,
+    ))
+    conn.commit()
+    conn.close()
+
+
+def _index_decoy_row(cfg, applied, subject):
+    """A second, unrelated row filed in the same folder as ``applied``'s file.
+
+    Gives the suggestion engine's FTS index something to rank for that folder
+    once the row for the reverted mail itself is gone -- otherwise "offered
+    again with candidates" can't be told apart from "offered again with an
+    empty candidate list because the index is now empty".
+    """
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    folder = Path(applied["files"][0]).parent
+    decoy_path = str(folder / "decoy.msg")
+    repo.upsert_email(EmailRecord(
+        file_path=decoy_path,
+        folder_path=str(folder),
+        filename="decoy.msg",
+        subject=subject,
+    ))
+    conn.commit()
+    conn.close()
+
+
+def test_revert_removes_the_index_row_so_the_next_plan_offers_the_mail_again(
+    cfg, archive_root
+):
+    """Regression for #57: revert used to leave the index row for the deleted
+    ``.msg`` in place, so the next `plan` reported the mail `already_archived`
+    at a path that no longer existed instead of offering it again."""
+    subject = "Stale index row"
+    item = _mail("a@example.invalid", subject)
+    client = FakeOutlookClient([item])
+    applied = _apply_one(cfg, archive_root, client)
+    _index_archived_file(cfg, applied, subject=subject)
+    _index_decoy_row(cfg, applied, subject=subject)
+
+    doc = batch.revert(client, cfg, [
+        {"message_id": "a@example.invalid", "files": applied["files"]},
+    ])
+    result = doc["results"][0]
+    assert result["ok"] is True
+    assert result["index_rows_removed"] == 1
+
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    assert repo.find_path_by_message_id("a@example.invalid") is None
+    conn.close()
+
+    plan_doc = batch.plan(client, cfg)
+    mail = plan_doc["mails"][0]
+    assert mail["already_archived"] is None
+    assert mail["candidates"], "the mail must be offered again with candidates"
+
+
+def test_revert_leaves_the_index_row_when_the_file_delete_fails(
+    cfg, archive_root, monkeypatch
+):
+    """A revert whose file delete failed must leave the row alone -- the file
+    is still there, so the index still describing it is correct, not stale."""
+    item = _mail("a@example.invalid", "Delete failure")
+    client = FakeOutlookClient([item])
+    applied = _apply_one(cfg, archive_root, client)
+    _index_archived_file(cfg, applied)
+
+    real_unlink = Path.unlink
+
+    def failing_unlink(self, *args, **kwargs):
+        if str(self) == str(Path(applied["files"][0])):
+            raise PermissionError("simulated: file is locked")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+    doc = batch.revert(client, cfg, [
+        {"message_id": "a@example.invalid", "files": applied["files"]},
+    ])
+    result = doc["results"][0]
+    assert result["file_errors"]
+    assert result["index_rows_removed"] == 0
+
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    assert repo.find_path_by_message_id("a@example.invalid") == applied["files"][0]
+    conn.close()
 
 
 def test_revert_refuses_a_file_outside_the_archive_roots(cfg, tmp_path):


### PR DESCRIPTION
## Summary

`revert` deleted a mail's archived files and moved it back to the Inbox, but never touched the SQLite index — the row for the deleted `.msg` survived until the next full scan. A `plan` run in between still found it through `find_path_by_message_id` and reported the mail `already_archived` at a path that no longer existed, so a run started before the next scan silently skipped a mail that was actually sitting in the Inbox (observed during the task-os walk, task-os#158).

- `EmailRepository.delete_by_path(file_path)` — a small counterpart to `delete_missing_emails`, next to it in `repository.py`.
- `revert` calls it right after successfully unlinking each `.msg` (never for attachments, and never when the delete itself failed — a failed delete leaves the file and its row both alone) and reports the count as `index_rows_removed` in the result. Additive field only; `schema_version` is unchanged.
- README's batch section and the internal architecture diagram note the new index consequence.

## Validation

**Automated gate** (this repo's declared gate is `pytest`; no linter is configured, so none was run and none is claimed)

- [x] `& .\.venv\Scripts\python.exe -m pytest tests/` — 128 passed, 0 failed, 0 skipped
- [x] Reproduction proof: `tests/test_batch.py::test_revert_removes_the_index_row_so_the_next_plan_offers_the_mail_again` fails against pre-fix code (confirmed by running it before the fix — `KeyError: 'index_rows_removed'`, and the underlying stale-row behavior is exactly the bug) and passes after
- [x] `tests/test_batch.py::test_revert_leaves_the_index_row_when_the_file_delete_fails` — a delete that raises `OSError` leaves the index row in place
- [x] Real walk against live Outlook: `plan` (read-only) → `apply` one real mail → `revert` it immediately → `plan` again with no scan in between; the mail came back with `already_archived: None` and 5 ranked candidates. Only one real mail was touched, reverted right away; scratch JSON with real content was deleted afterwards.
- [x] Independent fresh-agent review: re-ran the gate itself (128 passed), read the full diff and the issue's acceptance criteria independently — **pass**.

Closes #57

https://claude.ai/code/session_01XY1TW3d8mm8YDZDLqjjEdd
