### PR TITLE
fix: finish a mail whose move was refused as a changed message

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The project ships a pytest suite (`tests/`) covering the filename fitter, sequen
 | Verb | Reads | Does |
 |---|---|---|
 | `plan` | nothing | Starts Outlook if it is closed, enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10), each carrying its own `date_prefix`. Read-only. |
-| `apply` | `[{message_id, folder_path, date_prefix}]` | Archives each mail into `folder_path`, then moves it to the Outlook `Archive` folder and tags it with the category. |
+| `apply` | `[{message_id, folder_path, date_prefix}]` | Archives each mail into `folder_path`, then moves it to the Outlook `Archive` folder and tags it with the category. A mail already in the index is finished rather than filed again — see [Retrying a mail that was written but never moved](#retrying-a-mail-that-was-written-but-never-moved). |
 | `revert` | `[{message_id, files}]` | Deletes exactly the listed files, removes their index rows, removes the category and moves the mail back to the Inbox. |
 
 An `apply` result can be handed straight back to `revert` — the object with its `results` list is accepted as-is, no reshaping needed.
@@ -287,6 +287,19 @@ Per-mail `error.code` values: `bad_decision` (the entry had no `message_id` or `
 `apply` fills in a result's `files` **before** it moves the mail, so a mail that was written to disk but failed to move is still fully revertible — that is why a result can carry `ok: false` and a non-empty `files` at the same time.
 
 Every document carries `schema_version`, so a consumer can refuse a shape it does not understand rather than read a field that silently moved.
+
+### Retrying a mail that was written but never moved
+
+A mail can end up with its files on disk and its place in the Inbox kept: `SaveAs` leaves the in-memory Outlook item flagged as modified often enough that the `Move` right after it is refused with *"the operation cannot be performed because the message has been changed"* (MAPI `0x80040109`). That mail is reported `move_failed`, and every later `plan` reports it `already_archived` — its `.msg` is in the index — so without a retry path it could never leave the Inbox.
+
+Two things make it retryable:
+
+- **`apply` moves a reference it re-acquires from the store by EntryID**, not the one it just wrote to disk, and on a `0x80040109` from that reference too it saves it once and retries the move. Which of the three paths finished the move is logged and reported per result as `move_via`: `refetched` (the re-acquired reference was enough), `saved_retry` (it took a `Save()` and one more attempt) or `original` (the re-acquire failed, so the original reference was moved). A move that fails for any *other* reason is still a plain `move_failed`, never retried.
+- **`apply` accepts a decision for a mail `plan` reported `already_archived`** and finishes it: it writes nothing, moves the mail to the `Archive` folder, tags it, and reports the existing file as `files` with `reused: true` and an empty `sequence_number` (none was allocated). This is what a consumer offers as *retry* on such a mail. The one exception is an index row whose file is gone — no longer proof of anything, so that mail is archived for real instead.
+
+One case is beyond both defences and is called out by name in the result: when the running Outlook process itself is holding the item, every write to it is refused for the life of that process — a re-acquired reference and a `Save()` are refused exactly like the original. The mail keeps its `move_failed`, and the message says what to do: **restart Outlook, then apply the same decision again**. It then completes on the first attempt, and because the files are already on disk it writes nothing.
+
+`plan` also states `in_inbox` on every mail it reports. It is always `true` — `plan` enumerates the Inbox — but it is the fact that separates an `already_archived` mail *still sitting in the Inbox* from one that is properly filed and gone, so a consumer can key a retry offer off the document rather than off an assumption.
 
 ### Safety
 

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -74,14 +74,14 @@ flowchart TB
   ARCHIVER -->|writes .msg + attachments| ONEDRIVE
 
   subgraph batchflow["Batch mode data flow (headless, spawned by another app)"]
-    BATCH["batch.py\nplan · apply · revert —\npure orchestration, no COM, no tkinter.\nIdentity is the Internet Message-ID,\nnot EntryID (which a Move rewrites)"]
+    BATCH["batch.py\nplan · apply · revert —\npure orchestration, no COM, no tkinter.\nIdentity is the Internet Message-ID,\nnot EntryID (which a Move rewrites).\napply moves a re-acquired reference and\nfinishes an already-archived mail\nwithout writing anything"]
   end
   CALLER["another local app (task-os)\nspawns the process with a timeout,\nreads one JSON document"] -->|subprocess| MAINBATCH
   MAINBATCH --> BATCH
-  BATCH -->|ensure_running · iter_inbox · find_by_message_id · move_to · set_category| OUTLOOK
+  BATCH -->|ensure_running · iter_inbox · find_by_message_id ·\nrefetch · save_item · move_to · set_category| OUTLOOK
   OUTLOOK -->|starts if closed, polls GetActiveObject| OUTLOOKCOM
   BATCH -->|plan: rank folders per mail| SUGGESTER
-  BATCH -->|plan: already archived?| REPO
-  BATCH -->|apply: per-mail date_prefix| ARCHIVER
+  BATCH -->|plan + apply: already archived?| REPO
+  BATCH -->|apply: per-mail date_prefix,\nskipped entirely for a reused mail| ARCHIVER
   BATCH -->|revert: delete only inside archive.root_paths| ONEDRIVE
   BATCH -->|revert: delete_by_path per deleted .msg| REPO

--- a/email_archiver/batch.py
+++ b/email_archiver/batch.py
@@ -24,6 +24,17 @@ Design decisions:
 - **``files`` is filled in before the move**, so a mail that was written to disk
   but failed to move is still fully revertible from the ``apply`` output. That
   is why an entry can carry ``ok: false`` and a non-empty ``files`` at once.
+- **A mail is never archived twice.** ``apply`` re-checks the index per
+  decision: a mail already filed there (the one ``plan`` reports
+  ``already_archived``, still in the Inbox because an earlier run's move
+  failed) is *finished* rather than re-written — ``reused: true``, the existing
+  file reported back, nothing new on disk.
+- **The reference that is moved is not the one that was archived.**
+  ``MailItem.SaveAs`` can leave an item flagged as modified and ``Move`` then
+  refuses it with MAPI_E_OBJECT_CHANGED, which is how a mail ends up with its
+  files written and its place in the Inbox kept. ``apply`` moves a reference
+  re-acquired by EntryID, and on that refusal saves and retries once; which
+  path finished it is logged and reported as ``move_via``.
 - **``revert`` deletes only what it is given, and only inside the archive
   roots.** Anything resolving outside ``archive.root_paths`` is refused per
   file with a reason rather than deleted, so a malformed or hostile items file
@@ -46,7 +57,7 @@ from email_archiver.config import (
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRepository
 from email_archiver.engine.suggester import SuggestionEngine
-from email_archiver.outlook.client import EmailData
+from email_archiver.outlook.client import EmailData, is_message_changed_error
 from email_archiver.text import normalize_message_id
 
 logger = logging.getLogger(__name__)
@@ -79,6 +90,14 @@ ERROR_CATEGORY_FAILED = "category_failed"
 # Per-file outcomes in a revert result.
 REFUSED_OUTSIDE_ROOTS = "outside_archive_roots"
 REFUSED_UNRESOLVABLE = "unresolvable_path"
+
+# Which reference finished an `apply` move, reported as the result's
+# `move_via`. Three genuinely different stories about the same mail, and the
+# one place that says whether the re-acquire is earning its keep on this
+# mailbox — see `_move_out_of_inbox`.
+MOVE_VIA_REFETCHED = "refetched"     # a reference read back out of the store
+MOVE_VIA_ORIGINAL = "original"       # the re-acquire failed; the original moved
+MOVE_VIA_SAVED_RETRY = "saved_retry"  # refused with 0x80040109, saved, retried
 
 
 # ---------------------------------------------------------------- helpers ---
@@ -144,6 +163,13 @@ def _mail_dict(mail: Any) -> dict[str, Any]:
         "body_preview": mail.body_preview,
         "attachment_count": mail.attachment_count,
         "flag_status": mail.flag_status,
+        # Always true today — ``plan`` enumerates the Inbox, so a mail it
+        # reports is in it by construction. Stated anyway because it is the
+        # fact that makes an ``already_archived`` mail *retryable*: its files
+        # are on disk but it never left the Inbox, and a consumer reading only
+        # ``already_archived`` cannot tell that from a mail that is properly
+        # filed and gone (issue #59).
+        "in_inbox": True,
     }
 
 
@@ -303,6 +329,12 @@ def _blank_apply_result(message_id: str, folder_path: str) -> dict[str, Any]:
         "entry_id": "",
         "moved": False,
         "categorized": False,
+        # True when the mail was already on disk and this run only finished it
+        # in Outlook — nothing was written, and `files` is what was found, not
+        # what was created. `sequence_number` stays empty: none was allocated.
+        "reused": False,
+        # Which reference the move went through, "" when it never happened.
+        "move_via": "",
         "error": None,
     }
 
@@ -319,6 +351,14 @@ def apply(
     never reads the global ``naming.date_prefix`` toggle, because the caller
     infers the form the destination folder actually uses.
 
+    A decision for a mail the index already holds — the one ``plan`` reported
+    ``already_archived``, still sitting in the Inbox because an earlier run
+    wrote its files and then failed to move it — writes **nothing**: the
+    existing ``.msg`` is reported back as ``files``, ``reused`` is true, and
+    the mail is moved and tagged like any other. That is what makes such a mail
+    finishable at all; re-archiving it would file a second copy beside the
+    first (issue #59).
+
     Whatever happens to one mail, the next is still attempted; the per-mail
     ``error`` says what went wrong and ``files`` says what is already on disk.
     """
@@ -326,38 +366,97 @@ def apply(
     category = get_outlook_category(cfg)
     results: list[dict[str, Any]] = []
 
-    for raw in decisions:
-        message_id = normalize_message_id(raw.get("message_id"))
-        folder_path = str(raw.get("folder_path") or "")
-        result = _blank_apply_result(message_id, folder_path)
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    try:
+        for raw in decisions:
+            results.append(
+                _apply_one(client, cfg, repo, raw, archive_folder, category)
+            )
+    finally:
+        conn.close()
 
-        if not message_id or not folder_path:
-            result["error"] = {
-                "code": ERROR_BAD_DECISION,
-                "message": "a decision needs both a message_id and a folder_path",
-            }
-            results.append(result)
-            continue
+    doc = _envelope("apply", cfg)
+    applied = sum(1 for r in results if r["ok"])
+    doc["counts"] = {
+        "requested": len(results),
+        "applied": applied,
+        "failed": len(results) - applied,
+    }
+    doc["results"] = results
+    logger.info("Apply: %d of %d mail(s) filed.", applied, len(results))
+    return doc
 
-        item = None
-        try:
-            item = client.find_by_message_id(message_id, None)
-        except Exception as exc:  # a COM failure on one lookup, not the run
-            result["error"] = {
-                "code": ERROR_NOT_IN_INBOX,
-                "message": f"Inbox lookup failed: {type(exc).__name__}: {exc}",
-            }
-            results.append(result)
-            continue
 
-        if item is None:
-            result["error"] = {
-                "code": ERROR_NOT_IN_INBOX,
-                "message": "no mail with this Message-ID is in the Inbox",
-            }
-            results.append(result)
-            continue
+def _archived_file_to_reuse(repo: EmailRepository, message_id: str) -> str | None:
+    """The ``.msg`` this mail is already filed as, when it really is on disk.
 
+    An index row is not proof the file is still there: a row can outlive its
+    file (a manual delete, a move in Explorer). Reporting ``reused`` over a
+    path that no longer exists would leave the mail tagged and filed in Outlook
+    with nothing on disk to show for it, so an unbacked row falls through to a
+    normal archive instead.
+    """
+    path = repo.find_path_by_message_id(message_id)
+    if not path:
+        return None
+    if Path(path).exists():
+        return path
+    logger.info(
+        "The index has %s at %r but the file is gone; archiving it again.",
+        message_id, path,
+    )
+    return None
+
+
+def _apply_one(
+    client: Any,
+    cfg: dict[str, Any],
+    repo: EmailRepository,
+    raw: dict[str, Any],
+    archive_folder: str,
+    category: str,
+) -> dict[str, Any]:
+    """One decision, start to finish. Never raises: every failure is a result."""
+    message_id = normalize_message_id(raw.get("message_id"))
+    folder_path = str(raw.get("folder_path") or "")
+    result = _blank_apply_result(message_id, folder_path)
+
+    if not message_id or not folder_path:
+        result["error"] = {
+            "code": ERROR_BAD_DECISION,
+            "message": "a decision needs both a message_id and a folder_path",
+        }
+        return result
+
+    try:
+        item = client.find_by_message_id(message_id, None)
+    except Exception as exc:  # a COM failure on one lookup, not the run
+        result["error"] = {
+            "code": ERROR_NOT_IN_INBOX,
+            "message": f"Inbox lookup failed: {type(exc).__name__}: {exc}",
+        }
+        return result
+
+    if item is None:
+        result["error"] = {
+            "code": ERROR_NOT_IN_INBOX,
+            "message": "no mail with this Message-ID is in the Inbox",
+        }
+        return result
+
+    reused = _archived_file_to_reuse(repo, message_id)
+    if reused:
+        # Nothing to write: an earlier run already wrote this bundle and only
+        # the Outlook half of it is unfinished. Writing again would file a
+        # second copy of the same mail beside the first.
+        logger.info(
+            "Mail %s is already archived as %r; finishing it in Outlook "
+            "without writing anything.", message_id, reused,
+        )
+        result["reused"] = True
+        result["files"] = [reused]
+    else:
         try:
             mail = client.read_mail(item)
             archiver = EmailArchiver(
@@ -370,56 +469,120 @@ def apply(
                 "code": ERROR_ARCHIVE_FAILED,
                 "message": f"{type(exc).__name__}: {exc}",
             }
-            results.append(result)
-            continue
+            return result
 
         result["sequence_number"] = archived.sequence_number
         # Filled in before the move on purpose: if the move fails these files
         # exist and the caller must be able to revert them.
         result["files"] = [archived.email_path, *archived.attachment_paths]
 
-        try:
-            moved = client.move_to(item, archive_folder)
-            result["moved"] = True
-            result["entry_id"] = client.entry_id(moved)
-        except Exception as exc:
-            logger.exception("Moving %s to %r failed", message_id, archive_folder)
-            result["error"] = {
-                "code": ERROR_MOVE_FAILED,
-                "message": f"{type(exc).__name__}: {exc}",
-            }
-            results.append(result)
-            continue
+    try:
+        moved, via = _move_out_of_inbox(client, item, archive_folder, message_id)
+        result["moved"] = True
+        result["move_via"] = via
+        result["entry_id"] = client.entry_id(moved)
+    except Exception as exc:
+        logger.exception("Moving %s to %r failed", message_id, archive_folder)
+        result["error"] = {
+            "code": ERROR_MOVE_FAILED,
+            "message": f"{type(exc).__name__}: {exc}{_move_remedy(exc)}",
+        }
+        return result
 
-        # Tagged in its own step: a category that would not stick is a
-        # different state from a move that did not happen, and the caller
-        # recovers from the two differently.
-        try:
-            client.set_category(moved, category)
-            result["categorized"] = True
-        except Exception as exc:
-            logger.exception("Tagging %s with %r failed", message_id, category)
-            result["error"] = {
-                "code": ERROR_CATEGORY_FAILED,
-                "message": f"the mail was filed and moved, but not tagged: "
-                           f"{type(exc).__name__}: {exc}",
-            }
-            results.append(result)
-            continue
+    # Tagged in its own step: a category that would not stick is a different
+    # state from a move that did not happen, and the caller recovers from the
+    # two differently.
+    try:
+        client.set_category(moved, category)
+        result["categorized"] = True
+    except Exception as exc:
+        logger.exception("Tagging %s with %r failed", message_id, category)
+        result["error"] = {
+            "code": ERROR_CATEGORY_FAILED,
+            "message": f"the mail was filed and moved, but not tagged: "
+                       f"{type(exc).__name__}: {exc}",
+        }
+        return result
 
-        result["ok"] = True
-        results.append(result)
+    result["ok"] = True
+    return result
 
-    doc = _envelope("apply", cfg)
-    applied = sum(1 for r in results if r["ok"])
-    doc["counts"] = {
-        "requested": len(results),
-        "applied": applied,
-        "failed": len(results) - applied,
-    }
-    doc["results"] = results
-    logger.info("Apply: %d of %d mail(s) filed.", applied, len(results))
-    return doc
+
+def _move_remedy(exc: Exception) -> str:
+    """The sentence appended to a ``move_failed`` message, when there is one.
+
+    A move refused as *the message has been changed* even after the re-acquire
+    and the save-and-retry is its own condition, and a recoverable one: the
+    files are on disk, the mail is still in the Inbox, and the state that
+    refuses the write is held by the running Outlook process itself — a
+    restart clears it and re-applying the same decision then finishes the mail
+    without writing anything (observed on the mail in issue #59: refused on a
+    freshly re-acquired reference *and* on ``Save()``, moved on the first
+    attempt after Outlook was restarted). Saying so here is what makes the
+    next occurrence diagnosable from the run's own output.
+    """
+    if not is_message_changed_error(exc):
+        return ""
+    return (
+        " — Outlook refused the move as a changed message twice, on a "
+        "re-acquired reference and after saving it. The files are on disk and "
+        "the mail is still in the Inbox: restarting Outlook and applying this "
+        "same decision again finishes it without writing anything."
+    )
+
+
+def _move_out_of_inbox(
+    client: Any, item: Any, archive_folder: str, message_id: str
+) -> tuple[Any, str]:
+    """Move a just-archived mail out of the Inbox; return it and how it went.
+
+    ``MailItem.SaveAs`` can leave the in-memory item flagged as modified, and
+    ``Move`` on that same reference is then refused with MAPI_E_OBJECT_CHANGED
+    — the mail keeps its place in the Inbox with its files already on disk, and
+    the next ``plan`` reports it ``already_archived``, so batch mode could
+    never file it (issue #59). Two defences, in order:
+
+    1. move a reference re-acquired from the store by EntryID, which carries
+       none of the original's modified state;
+    2. on a 0x80040109 anyway, ``Save()`` that reference — which is what clears
+       the flag — and retry the move exactly once.
+
+    Any other failure is raised untouched: a store that refuses a move for a
+    different reason is a different problem, and retrying it would only hide
+    it. Which of the three paths ran is logged and reported as ``move_via``,
+    because "the re-acquire was enough" and "it took a save and a retry" are
+    the two facts that say whether this fix is holding on a real mailbox.
+    """
+    target, via = item, MOVE_VIA_ORIGINAL
+    try:
+        fresh = client.refetch(item)
+    except Exception as exc:  # a refetch that raises is still just a fallback
+        fresh = None
+        logger.warning("Re-acquiring %s by EntryID raised %s: %s",
+                       message_id, type(exc).__name__, exc)
+    if fresh is not None:
+        target, via = fresh, MOVE_VIA_REFETCHED
+    else:
+        logger.info(
+            "Could not re-acquire %s from the store; moving the original "
+            "reference.", message_id,
+        )
+
+    try:
+        moved = client.move_to(target, archive_folder)
+    except Exception as exc:
+        if not is_message_changed_error(exc):
+            raise
+        logger.info(
+            "Outlook refused to move %s (the message has been changed) on the "
+            "%s reference; saving it and retrying once.", message_id, via,
+        )
+        client.save_item(target)
+        moved = client.move_to(target, archive_folder)
+        via = MOVE_VIA_SAVED_RETRY
+
+    logger.info("Moved %s to %r via the %s reference.", message_id, archive_folder, via)
+    return moved, via
 
 
 # ----------------------------------------------------------------- revert ---

--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -11,8 +11,9 @@ Design decisions:
   important for the fast-launch requirement. ensure_running() is its deliberate
   opposite, used only by batch mode, which has no user to open Outlook for it.
 - The batch surface (ensure_running / iter_inbox / find_by_message_id /
-  move_to / set_category / clear_category) lives here too, so batch.py stays
-  pure orchestration and can be driven by a fake client in tests.
+  refetch / save_item / move_to / set_category / clear_category) lives here
+  too, so batch.py stays pure orchestration and can be driven by a fake client
+  in tests.
 """
 from __future__ import annotations
 
@@ -239,6 +240,36 @@ DASL_FLAG_STATUS = "http://schemas.microsoft.com/mapi/proptag/0x10900003"
 # COM object. Outlook's first start on a cold profile is genuinely slow.
 DEFAULT_START_TIMEOUT_SECONDS = 60.0
 _POLL_INTERVAL_SECONDS = 1.0
+
+# MAPI_E_OBJECT_CHANGED. Outlook raises it from MailItem.Move (and Delete, and
+# Save) when it considers the in-memory item to have been modified since it was
+# obtained — which SaveAs can leave an item as, on the very reference the
+# archiver just wrote to disk. Batch mode tells this one refusal apart from
+# every other move failure because it is the only one worth retrying.
+MAPI_E_OBJECT_CHANGED = 0x80040109
+
+
+def is_message_changed_error(exc: Any) -> bool:
+    """Whether a COM failure is MAPI_E_OBJECT_CHANGED (0x80040109).
+
+    ``pywintypes.com_error`` carries the interesting code in its ``excepinfo``
+    tuple (``args[2][5]``) rather than in the HRESULT, which for a scripted
+    Outlook call is the generic ``DISP_E_EXCEPTION``. So every integer in
+    ``args``, one level of nesting deep, is compared — masked to 32 bits, since
+    the same code is spelled both signed (``-2147221239``) and unsigned
+    depending on where it came from.
+
+    Deliberately keyed on the code and never on the message text: the message
+    is localised, and matching "has been changed" would silently stop matching
+    on a non-English Outlook.
+    """
+    codes: list[int] = []
+    for arg in getattr(exc, "args", ()) or ():
+        if isinstance(arg, int):
+            codes.append(arg)
+        elif isinstance(arg, tuple):
+            codes.extend(inner for inner in arg if isinstance(inner, int))
+    return any(code & 0xFFFFFFFF == MAPI_E_OBJECT_CHANGED for code in codes)
 
 
 def split_categories(raw: str | None) -> list[str]:
@@ -646,6 +677,44 @@ class OutlookClient:
             except Exception as exc:
                 logger.warning("Skipping unreadable item %d during lookup: %s", i, exc)
         return None
+
+    def refetch(self, item: Any) -> Any | None:
+        """Re-acquire a mail from the store by its ``EntryID``, or ``None``.
+
+        ``MailItem.SaveAs`` can leave the in-memory item flagged as modified,
+        and a later ``Move`` on *that* reference is then refused with
+        MAPI_E_OBJECT_CHANGED — the mail stays in the Inbox with its files
+        already on disk (issue #59). A reference read back through
+        ``Session.GetItemFromID`` is a fresh object carrying none of that
+        state, so it is what batch mode moves.
+
+        ``None`` (never an exception) when the item has no readable EntryID or
+        the store cannot hand it back: failing to re-acquire is a reason to
+        move the original reference, not a reason to strand the mail.
+        """
+        entry_id = _safe_com(lambda: str(item.EntryID), "")
+        if not entry_id:
+            logger.warning("Cannot re-acquire a mail with no readable EntryID.")
+            return None
+        try:
+            import win32com.client  # noqa: PLC0415
+
+            fresh = self._namespace().GetItemFromID(entry_id)
+        except Exception as exc:
+            logger.warning("GetItemFromID failed for %s: %s", entry_id, exc)
+            return None
+        if fresh is None:
+            return None
+        return win32com.client.Dispatch(fresh)
+
+    def save_item(self, item: Any) -> None:
+        """Commit a mail's pending changes.
+
+        Its own method rather than an inline ``item.Save()`` in batch mode:
+        ``batch.py`` touches no COM object, and this is the call that clears
+        the modified flag behind a MAPI_E_OBJECT_CHANGED before the one retry.
+        """
+        item.Save()
 
     def move_to(self, item: Any, folder_name: str | None) -> Any:
         """Move a mail to a folder and return the moved item.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -31,6 +31,7 @@ from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
 from email_archiver.outlook.client import (
     InboxMail,
+    is_message_changed_error,
     with_category,
     without_category,
 )
@@ -48,6 +49,38 @@ class _FakePropertyAccessor:
         if key in self._props:
             return self._props[key]
         raise RuntimeError(f"property not found: {key}")
+
+
+class _FakeComError(Exception):
+    """A ``pywintypes.com_error`` look-alike.
+
+    Same ``args`` shape as the real thing — ``(hresult, description, excepinfo,
+    argerror)`` with the MAPI scode buried in ``excepinfo[5]`` — so the
+    detection helper is exercised exactly as it will be against Outlook, with
+    no pywin32 import in the test suite.
+    """
+
+
+def _message_changed_error() -> _FakeComError:
+    """The failure this issue is about: MAPI_E_OBJECT_CHANGED (0x80040109).
+
+    Raised by ``MailItem.Move`` on an item Outlook considers modified — which
+    ``SaveAs`` can leave it as, on the very same reference the archiver just
+    wrote to disk.
+    """
+    return _FakeComError(
+        -2147352567,
+        "Exception occurred.",
+        (
+            4096,
+            "Microsoft Outlook",
+            "The operation cannot be performed because the message has been changed.",
+            None,
+            0,
+            -2147221239,
+        ),
+        None,
+    )
 
 
 class _FakeAttachment:
@@ -105,6 +138,14 @@ class FakeOutlookClient:
     def __init__(self, inbox: list[_FakeMailItem]) -> None:
         self.folders: dict[str | None, list[_FakeMailItem]] = {None: list(inbox)}
         self.move_should_fail = False
+        # One Move refused with 0x80040109 before the store accepts it — the
+        # shape issue #59 hit on a real mailbox.
+        self.move_message_changed_once = False
+        # Every Move refused with 0x80040109 — the state the real mailbox was
+        # in until Outlook itself was restarted (issue #59).
+        self.move_message_changed_always = False
+        self.refetch_should_fail = False
+        self.refetched: list[str] = []
         self.category_should_fail = False
         self.moves: list[tuple[str, str | None]] = []
 
@@ -136,9 +177,26 @@ class FakeOutlookClient:
                 return item
         return None
 
+    def refetch(self, item: _FakeMailItem) -> _FakeMailItem | None:
+        """Stand-in for ``Session.GetItemFromID`` — a reference straight from
+        the store, which on a real mailbox is a *different* COM object carrying
+        none of the modified state ``SaveAs`` left on the original."""
+        if self.refetch_should_fail:
+            raise _FakeComError(-2147221233, "The item could not be found.", None, None)
+        self.refetched.append(item.EntryID)
+        return item
+
+    def save_item(self, item: _FakeMailItem) -> None:
+        item.Save()
+
     def move_to(self, item: _FakeMailItem, folder_name: str | None):
         if self.move_should_fail:
             raise RuntimeError("the store refused the move")
+        if self.move_message_changed_always:
+            raise _message_changed_error()
+        if self.move_message_changed_once:
+            self.move_message_changed_once = False
+            raise _message_changed_error()
         for name, items in self.folders.items():
             if item in items:
                 items.remove(item)
@@ -244,7 +302,7 @@ def test_plan_lists_every_inbox_mail_with_ranked_candidates(cfg, archive_root):
     assert set(first) == {
         "message_id", "entry_id", "subject", "sender", "recipients", "date_sent",
         "body_preview", "attachment_count", "flag_status", "already_archived",
-        "candidates",
+        "in_inbox", "candidates",
     }
     assert first["already_archived"] is None
     assert first["candidates"], "a seeded index must produce candidates"
@@ -367,6 +425,9 @@ def test_plan_marks_an_already_archived_mail_and_offers_no_candidates(
         archive_root / "Project Alpha" / "007 - already.msg"
     )
     assert archived["candidates"] == []
+    # Its files are on disk but it is still sitting in the Inbox: the shape a
+    # consumer offers a retry for (issue #59).
+    assert archived["in_inbox"] is True
     assert fresh["already_archived"] is None
     assert doc["counts"]["already_archived"] == 1
     assert doc["counts"]["planned"] == 1
@@ -419,8 +480,9 @@ def test_apply_writes_the_bundle_moves_the_mail_and_tags_it(cfg, archive_root):
     result = doc["results"][0]
     assert set(result) == {
         "message_id", "folder_path", "ok", "sequence_number", "files",
-        "entry_id", "moved", "categorized", "error",
+        "entry_id", "moved", "categorized", "reused", "move_via", "error",
     }
+    assert result["reused"] is False
     assert result["ok"] is True
     assert result["error"] is None
     assert result["sequence_number"] == "001"
@@ -538,6 +600,200 @@ def test_apply_tells_a_failed_tag_apart_from_a_failed_move(cfg, archive_root):
     assert result["categorized"] is False
     assert client.folders["Archive"] == [item], "the mail really is filed"
     assert result["files"] and Path(result["files"][0]).exists()
+
+
+def test_apply_moves_a_reference_re_acquired_from_the_store(cfg, archive_root):
+    """The mail archived is not the reference moved (issue #59).
+
+    ``SaveAs`` can leave the in-memory MailItem flagged as modified; moving a
+    reference read back out of the store by EntryID is what avoids the
+    0x80040109 that flag causes.
+    """
+    dest = archive_root / "Project Alpha"
+    item = _mail("a@example.invalid", "Fresh reference")
+    client = FakeOutlookClient([item])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is True
+    assert result["move_via"] == batch.MOVE_VIA_REFETCHED
+    assert client.refetched == ["entry-a@example.invalid"]
+
+
+def test_apply_saves_and_retries_once_when_the_message_has_been_changed(
+    cfg, archive_root
+):
+    """The reported failure: the first Move is refused with 0x80040109.
+
+    A store that refuses the fresh reference too gets one ``Save()``-then-Move
+    before ``apply`` gives up, and the result says which path finished it.
+    """
+    dest = archive_root / "Project Alpha"
+    item = _mail("a@example.invalid", "Changed underfoot")
+    client = FakeOutlookClient([item])
+    client.move_message_changed_once = True
+    saves_before = item.save_calls
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is True, "a changed message must not strand the mail"
+    assert result["moved"] is True
+    assert result["error"] is None
+    assert result["move_via"] == batch.MOVE_VIA_SAVED_RETRY
+    assert item.save_calls > saves_before, "the retry must Save() first"
+    assert client.folders[None] == [], "the Inbox must lose the mail"
+    assert client.folders["Archive"] == [item]
+    assert result["entry_id"] == "entry-a@example.invalid-in-Archive"
+
+
+def test_apply_still_moves_when_the_item_cannot_be_re_acquired(cfg, archive_root):
+    """A failed re-acquire is a fallback, not a failure: the original
+    reference is moved and the result says so."""
+    dest = archive_root / "Project Alpha"
+    item = _mail("a@example.invalid", "No fresh copy")
+    client = FakeOutlookClient([item])
+    client.refetch_should_fail = True
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is True
+    assert result["move_via"] == batch.MOVE_VIA_ORIGINAL
+    assert client.folders["Archive"] == [item]
+
+
+def test_apply_reports_a_move_that_fails_for_another_reason_unchanged(
+    cfg, archive_root
+):
+    """Only 0x80040109 earns the retry — any other refusal is still a
+    ``move_failed`` with the files reported for a revert."""
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("a@example.invalid", "Refused outright")])
+    client.move_should_fail = True
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is False
+    assert result["error"]["code"] == batch.ERROR_MOVE_FAILED
+    assert result["move_via"] == ""
+    assert result["files"] and Path(result["files"][0]).exists()
+
+
+def test_a_move_refused_twice_as_changed_says_how_to_recover(cfg, archive_root):
+    """The state the real mailbox was in: refused on the re-acquired reference
+    and after saving it too, because the running Outlook process itself was
+    holding the item. The message has to say that, or the next occurrence is a
+    bare HRESULT again."""
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("a@example.invalid", "Stuck fast")])
+    client.move_message_changed_always = True
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is False
+    assert result["error"]["code"] == batch.ERROR_MOVE_FAILED
+    assert "restarting Outlook" in result["error"]["message"]
+    assert "without writing anything" in result["error"]["message"]
+    assert result["files"], "the files are on disk and must be reported"
+    assert client.folders[None], "the mail is still in the Inbox"
+
+
+def test_apply_finishes_an_already_archived_mail_without_writing_files(
+    cfg, archive_root
+):
+    """The second half of issue #59: a mail whose files are already on disk but
+    which never left the Inbox can be finished by applying a decision for it.
+
+    Nothing new is written, the existing ``.msg`` is reported back, and the
+    mail is moved and tagged like any other.
+    """
+    dest = archive_root / "Project Alpha"
+    dest.mkdir(parents=True)
+    existing = dest / "007 - Already written.msg"
+    existing.write_text("synthetic .msg", encoding="utf-8")
+
+    conn = init_db(cfg["database"]["path"])
+    EmailRepository(conn).upsert_email(EmailRecord(
+        file_path=str(existing),
+        folder_path=str(dest),
+        filename=existing.name,
+        subject="Already written",
+        file_mtime=99.0,
+        message_id="a@example.invalid",
+    ))
+    conn.commit()
+    conn.close()
+
+    item = _mail("a@example.invalid", "Already written")
+    client = FakeOutlookClient([item])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is True
+    assert result["reused"] is True
+    assert result["files"] == [str(existing)]
+    assert result["sequence_number"] == ""
+    assert item.saved_as == [], "nothing may be written for a reused mail"
+    assert list(dest.iterdir()) == [existing], "no new file in the folder"
+    assert client.folders[None] == []
+    assert client.folders["Archive"] == [item]
+    assert item.Categories == "Filed by batch"
+    assert result["moved"] is True and result["categorized"] is True
+
+
+def test_apply_archives_again_when_the_indexed_file_is_gone(cfg, archive_root):
+    """A stale index row is not proof the files are there: the mail is filed
+    for real rather than reported as reused over a path that no longer exists.
+    """
+    dest = archive_root / "Project Alpha"
+    conn = init_db(cfg["database"]["path"])
+    EmailRepository(conn).upsert_email(EmailRecord(
+        file_path=str(dest / "007 - Deleted since.msg"),
+        folder_path=str(dest),
+        filename="007 - Deleted since.msg",
+        subject="Deleted since",
+        file_mtime=99.0,
+        message_id="a@example.invalid",
+    ))
+    conn.commit()
+    conn.close()
+
+    client = FakeOutlookClient([_mail("a@example.invalid", "Deleted since")])
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    result = doc["results"][0]
+    assert result["ok"] is True
+    assert result["reused"] is False
+    assert Path(result["files"][0]).name == "001 - Deleted since.msg"
+    assert Path(result["files"][0]).exists()
+
+
+def test_a_changed_message_is_told_apart_from_any_other_com_failure():
+    """The retry is keyed on the MAPI scode, not on the message text."""
+    assert is_message_changed_error(_message_changed_error()) is True
+    assert is_message_changed_error(
+        _FakeComError(-2147221233, "The item could not be found.", None, None)
+    ) is False
+    assert is_message_changed_error(RuntimeError("the store refused the move")) is False
 
 
 def test_apply_accepts_a_bracketed_message_id_from_the_caller(cfg, archive_root):


### PR DESCRIPTION
## Summary

A mail could be written to disk and still never leave the Inbox. `apply` archived it with `SaveAs` and then called `Move` on that same Outlook reference, which Outlook refuses with MAPI_E_OBJECT_CHANGED (`0x80040109`, *"the operation cannot be performed because the message has been changed"*). The mail was reported `move_failed`, kept its place in the Inbox without the category, and every later `plan` reported it `already_archived` — so batch mode could never file it, in any run.

Both halves are fixed:

- **The reference that is moved is no longer the one that was archived.** `OutlookClient.refetch(item)` re-acquires the mail from the store by `EntryID` through `Session.GetItemFromID`, and `apply` moves that. On a `0x80040109` from the fresh reference too, it calls `OutlookClient.save_item` and retries the move exactly once. Any other refusal is still a plain `move_failed`, never retried. Which of the three paths finished the move is logged and reported per result as `move_via` (`refetched` · `saved_retry` · `original`).
- **An already-archived mail can be finished.** `apply` re-checks the index per decision: a mail already filed there writes **nothing** — the existing `.msg` comes back as `files` with `reused: true` and an empty `sequence_number` — and is moved and tagged like any other. An index row whose file is gone is not proof of anything, so that mail is archived for real instead.
- `plan` now states `in_inbox` per mail, so a consumer can tell an `already_archived` mail *still sitting in the Inbox* from one properly filed and gone, and offer the retry.

### One thing the issue did not predict, found on the real mailbox

The re-acquire and the save-and-retry are not always enough. On the actual stuck mail, `Move` was refused **on a freshly re-acquired reference**, and `Save()` on it raised the identical HRESULT — while `MailItem.Saved` read `True`, the item was not in a sync conflict, a send/receive changed nothing, and neither did taking the reading pane off it. The state is held by the **running Outlook process itself** and lasts for the life of that process. After Outlook was restarted the same decision moved the mail on the first attempt.

So that condition now gets its own message rather than a bare HRESULT: a move refused as changed twice says the files are on disk, the mail is still in the Inbox, and that restarting Outlook and applying the same decision again finishes it without writing anything. That is the breadcrumb that makes the next occurrence diagnosable from the run's own output.

## For the consumer (task-os, follow-up there — not touched by this PR)

`src/archive_batch.py` maps a `failed` item with files on disk into its `_has_files_on_disk` / undoable shapes, and treats an `already_archived` plan mail as `status: archived, apply: False` — nothing is ever re-offered. To surface the retry this PR makes possible:

- For a `failed` item whose `files` is non-empty (a `move_failed`, which `apply` deliberately fills `files` for), offer **Retry** alongside Undo: re-send the *same* decision (`message_id` + the folder the files are already in) through `apply`. The archiver now writes nothing and returns `reused: true`, so the retry is safe to press twice.
- For a plan mail carrying `already_archived` **and** `in_inbox: true`, that mail is not finished — its files exist but it never left the Inbox. It can be offered as a one-click retry with `folder_path` taken from the parent folder of `already_archived`, instead of being recorded as `archived` with nothing to do.
- A retry that comes back `move_failed` again with the *restart Outlook* remedy in `error.message` is worth showing verbatim: it is the one case the user has to act on outside task-os.

No `schema_version` bump: `reused` and `move_via` on an `apply` result and `in_inbox` on a `plan` mail are additive, and nothing was renamed or removed, so today's consumer keeps parsing unchanged.

## Validation

- **Reproduction, before and after.** A standalone script drove `batch.apply` with a fake client whose first `Move` raises the exact `com_error` shape. Against pre-fix code: `ok: False`, `move_failed`, mail still in the Inbox, files on disk — and the second half wrote a *duplicate* `.msg` beside the existing one. Against the fix: `ok: True`, `move_via: saved_retry`, Inbox empty, mail in `Archive`; and the already-archived decision reported `reused: true` with no new file. The new unit tests were also confirmed to fail against pre-fix source (`git stash` of the two source files).
- **Gate — `& .\.venv\Scripts\python.exe -m pytest tests/`: 136 passed**, 8 of them new on this branch. Byte-compile of the three changed modules clean. This repo declares that pytest run as its whole gate: there is no ruff config, no e2e suite and no CI workflow, so nothing else was skipped or claimed.
- **Real walk against the live mailbox** (the one mail that was in this state; no other mail was applied). `plan --candidates 3` reported it `already_archived`, `in_inbox: true`, no candidates. A one-entry decisions file for that mail only was applied: with the stale Outlook process it was refused on the re-acquired reference *and* on `Save()`; after an Outlook restart the same command completed — `ok: true`, `reused: true`, `move_via: refetched`, `moved: true`, `categorized: true`, `sequence_number: ""`, `files` = the existing `.msg`. Verified afterwards: gone from the Inbox, present in the `Archive` folder carrying the configured category, and the destination folder held **exactly the same 32 files before and after**, byte-for-byte the same listing.
- **Independent review** by a fresh agent that fetched the acceptance criteria itself, read the diff and re-ran the gate on its own: `pass: true`.
- Sanity sweep of `git diff main...HEAD`: five files, no dependency change, no test removed, no assertion weakened, no `.gitignore` edit. No real folder name, address or subject anywhere in the diff.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m pytest tests/` — 136 passed
- [x] New unit test: a fake client whose first `Move` raises the `0x80040109` shape — `apply` re-fetches, saves, retries, and completes with `moved: true`
- [x] New unit test: a decision for an `already_archived` mail moves and tags it, writes no file, reports `reused: true`
- [x] New unit tests: a failed re-acquire still moves the original; any other move failure is unchanged; a move refused twice as changed says how to recover; a stale index row is archived for real
- [x] Real mail walked end to end: moved to `Archive`, category set, destination folder unchanged on disk
- [x] `docs/architecture.mmd` and the README batch section updated in this PR

Closes #59

https://claude.ai/code/session_01XY1TW3d8mm8YDZDLqjjEdd
