### PR TITLE
feat: renumber a folder chronologically and return the old-to-new map

### DIFF
--- a/.fleet.toml
+++ b/.fleet.toml
@@ -4,5 +4,5 @@
 # description, exposed services). Schema: fleet-config/architecture/README.md.
 layer       = "working-pipe"
 icon        = "📧"
-description = "Outlook → OneDrive archive. Its SQLite index records the follow-up flag, which task-os polls read-only to raise a task per flagged mail; main_batch.py exposes headless plan/apply/revert over the whole Inbox with JSON I/O for the same consumer."
+description = "Outlook → OneDrive archive. Its SQLite index records the follow-up flag, which task-os polls read-only to raise a task per flagged mail; main_batch.py exposes headless plan/apply/revert over the whole Inbox plus a renumber verb that re-sequences a folder into sent-date order, all with JSON I/O for the same consumer."
 tag         = ["→", "OneDrive"]

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ archiver/
 ├── email_archiver/              ← Main package
 │   ├── config.py                ← YAML loader, path resolution, logging setup
 │   ├── text.py                  ← Shared subject + Message-ID normalisation
-│   ├── batch.py                 ← Headless plan/apply/revert orchestration (no COM, no tkinter)
+│   ├── paths.py                 ← Archive-root guard shared by revert and renumber
+│   ├── batch.py                 ← Headless plan/apply/revert/renumber orchestration (no COM, no tkinter)
+│   ├── renumber.py              ← Re-sequence a folder into sent-date order
 │   ├── explorer.py              ← Foremost open Explorer window → folder path
 │   │
 │   ├── database/
@@ -139,7 +141,7 @@ archiver/
 ├── main_archive.py              ← Stream Deck entry: Archive Email
 ├── main_scan.py                 ← Stream Deck entry: Scan Archive
 ├── main_ui.py                   ← Full launcher (both buttons)
-├── main_batch.py                ← Headless entry: plan / apply / revert the whole Inbox (JSON)
+├── main_batch.py                ← Headless entry: plan / apply / revert / renumber (JSON)
 ├── launch_archive.bat           ← Runs pythonw main_archive.py (no console)
 ├── launch_scan.bat              ← Runs pythonw main_scan.py (no console)
 └── requirements.txt
@@ -243,7 +245,7 @@ The `.bat` files use `pythonw` so no console window flashes on screen.
 
 ## Verification
 
-The project ships a pytest suite (`tests/`) covering the filename fitter, sequencing, the date-prefix toggle, the Explorer picker, the `is_running()` regression, the Message-ID column and its migration, and every batch verb end to end against a fake Outlook client. Run it before declaring any change done:
+The project ships a pytest suite (`tests/`) covering the filename fitter, sequencing, the date-prefix toggle, the Explorer picker, the `is_running()` regression, the Message-ID column and its migration, renumbering (ordering, both name forms, split numbers, the dry run, the index), and every batch verb end to end against a fake Outlook client. Run it before declaring any change done:
 
 ```powershell
 & .\.venv\Scripts\python.exe -m pytest tests/
@@ -255,12 +257,13 @@ The project ships a pytest suite (`tests/`) covering the filename fitter, sequen
 
 ## Batch mode (headless)
 
-`main_batch.py` is the archiver's headless face: three verbs that file the **whole Inbox** in one run instead of one selected mail at a time, each printing exactly one JSON document on stdout. It exists so another local app can drive the archiver as a subprocess — the archiver stays the sole owner of Outlook COM, the suggestion engine and the naming rules, and the caller only decides *which folder* each mail goes to.
+`main_batch.py` is the archiver's headless face: four verbs — three that file the **whole Inbox** in one run instead of one selected mail at a time, plus one that repairs a folder's numbering — each printing exactly one JSON document on stdout. It exists so another local app can drive the archiver as a subprocess — the archiver stays the sole owner of Outlook COM, the suggestion engine and the naming rules, and the caller only decides *which folder* each mail goes to.
 
 ```powershell
 & .\.venv\Scripts\python.exe main_batch.py plan --candidates 5 > plan.json
 & .\.venv\Scripts\python.exe main_batch.py apply --decisions decisions.json
 & .\.venv\Scripts\python.exe main_batch.py revert --items revert.json
+& .\.venv\Scripts\python.exe main_batch.py renumber --folder "<a folder>" --dry-run
 ```
 
 | Verb | Reads | Does |
@@ -268,6 +271,7 @@ The project ships a pytest suite (`tests/`) covering the filename fitter, sequen
 | `plan` | nothing | Starts Outlook if it is closed, enumerates the Inbox, and returns every mail with its metadata and the top `--candidates` folder suggestions (default 10), each carrying its own `date_prefix`. Read-only. |
 | `apply` | `[{message_id, folder_path, date_prefix}]` | Archives each mail into `folder_path`, then moves it to the Outlook `Archive` folder and tags it with the category. A mail already in the index is finished rather than filed again — see [Retrying a mail that was written but never moved](#retrying-a-mail-that-was-written-but-never-moved). |
 | `revert` | `[{message_id, files}]` | Deletes exactly the listed files, removes their index rows, removes the category and moves the mail back to the Inbox. |
+| `renumber` | nothing | Re-sequences one folder into sent-date order and prints the old → new map. Touches no Outlook and no COM — see [Renumbering a folder](#renumbering-a-folder). |
 
 An `apply` result can be handed straight back to `revert` — the object with its `results` list is accepted as-is, no reshaping needed.
 
@@ -280,7 +284,7 @@ Outlook rewrites a mail's `EntryID` when it is moved between folders, which is e
 | Exit | Meaning |
 |---|---|
 | `0` | The run completed and stdout carries its document. Individual mails may still have failed — each result has its own `error` with a `code`. One failing mail never aborts the run. |
-| `2` | The run could not start. stdout carries `{"error": {"code", "message"}}` instead of results; the code is one of `config_missing` (no config, **or** one that could not be loaded — a malformed `config.yaml` lands here too, with the parser error in `message`), `bad_input`, `outlook_unavailable`, `com_unavailable`. |
+| `2` | The run could not start, or `renumber` could not finish its one folder. stdout carries `{"error": {"code", "message"}}` instead of results; the code is one of `config_missing` (no config, **or** one that could not be loaded — a malformed `config.yaml` lands here too, with the parser error in `message`), `bad_input`, `outlook_unavailable`, `com_unavailable`. A folder outside `archive.root_paths` is a `bad_input`, and so is a renumber that stopped part-way: no map is printed, because a map the disk may not match is worse than none. |
 
 Per-mail `error.code` values: `bad_decision` (the entry had no `message_id` or `folder_path`), `not_in_inbox`, `not_in_archive_folder`, `archive_failed`, `move_failed`, `category_failed`. The last two are deliberately distinct: after a `move_failed` the mail is still in the Inbox, after a `category_failed` it is already filed and only *looks* untouched in Outlook.
 
@@ -301,8 +305,51 @@ One case is beyond both defences and is called out by name in the result: when t
 
 `plan` also states `in_inbox` on every mail it reports. It is always `true` — `plan` enumerates the Inbox — but it is the fact that separates an `already_archived` mail *still sitting in the Inbox* from one that is properly filed and gone, so a consumer can key a retry offer off the document rather than off an assumption.
 
+### Renumbering a folder
+
+The `NNN` prefix is meant to be browsable: opening a project folder and reading down the list should be reading the thread in the order it happened. Two ordinary batch operations break that, and neither is a bug in how a single mail is archived — `revert` deletes a bundle and leaves a hole, and `apply` always allocates `max + 1`, so a mail filed into a folder after a correction takes the highest number even when it is older than everything already there.
+
+`renumber` is the repair:
+
+```powershell
+& .\.venv\Scripts\python.exe main_batch.py renumber --folder "<a folder>" --dry-run
+& .\.venv\Scripts\python.exe main_batch.py renumber --folder "<a folder>"
+```
+
+`--dry-run` computes and prints exactly the same map without renaming anything, so a run is always previewable. The same repair can be chained onto the two verbs that cause the problem — `apply --renumber` renumbers every destination folder the run wrote into, `revert --renumber` closes the gap in every folder the run deleted from — once per folder, after the verb's own work. Without the flag both verbs behave exactly as before and neither reports anything new.
+
+**The ordering rule**, in one place:
+
+- **Sent date decides.** Bundles are ordered by the mail's sent date, taken from the index and read out of the `.msg` itself when the index has no row for it (a file archived since the last scan). A bundle whose date cannot be established at all keeps its current position rather than being swept to one end.
+- **The unit is a bundle** — a sequence number and every file carrying it. An email never parts company with its attachments. A number that carries no `.msg` at all (an attachment whose mail was deleted by hand, a document filed into the sequence) still holds a slot, because leaving it behind would park it on a number that now belongs to a different mail.
+- **Numbers are contiguous from the folder's lowest existing one**, not from `001`. A folder that starts at `079` because it continues another folder's sequence keeps starting at `079`.
+- **Each file keeps its own name form** — `NNN - ` stays undated, `YYYY-MM-DD - NNN - ` keeps its date. A folder holding a mix keeps the mix.
+- **Two mails that ended up on one number are split by date**, and their attachments are matched to the right one by asking each `.msg` what it carries. An attachment that still cannot be placed follows the earlier mail and the map says so, as `attachments_placed`.
+- **Files with no sequence prefix are left alone** and reported under `skipped`.
+- **A folder outside `archive.root_paths` is refused**, untouched.
+
+**The consumer must heal its stored paths from the map.** A renumber renames files another app may be holding paths to; the archiver updates its own index and nothing else. The map is reported under `renumbered`, keyed by folder, in all three verbs that produce one:
+
+```json
+"renumbered": {
+  "<folder>": [
+    {
+      "from": "<folder>\\003 - subject.msg",
+      "to":   "<folder>\\002 - subject.msg",
+      "message_id": "abc123@mail.example",
+      "attachments": [["<folder>\\003 - report.pdf", "<folder>\\002 - report.pdf"]]
+    }
+  ]
+}
+```
+
+Only bundles that actually changed appear. `from`/`to` are `null` for a bundle that has no `.msg` (its files are all in `attachments`), so a consumer healing `.msg` paths simply has nothing to do for it. A folder that could **not** be renumbered is never an empty map in there — an empty map means "already in order" — it is listed under `renumber_refused` with its reason. The key is additive: `schema_version` is unchanged, and a consumer that does not know about it reads the rest of the document exactly as before.
+
 ### Safety
 
+- `renumber` renames **only** inside the folder it is given, and only when that folder resolves inside `archive.root_paths`. It never reads or writes file contents, lists the folder once, and renames only the files whose number actually changes.
+- Renames run in two phases through a same-length `~XX` placeholder, because closing a gap gives a file the name of the file next to it. The placeholder is the same length as the number it replaces, so a path that fits Windows' `MAX_PATH` today still fits mid-rename. A run that stops part-way logs exactly which files are still under a placeholder.
+- The index follows the same two phases: `emails.file_path` is UNIQUE, and two mails on one thread share a subject, so a reorder routinely hands one of them the exact path the other still holds. A row left on a name a rename is about to take, whose own file is gone, is dropped and counted separately as `index_rows_dropped` — "the index followed the renames" and "the index was also wrong" are two different facts.
 - `revert` deletes **only** the files it is given, and only those that resolve inside `archive.root_paths`. Anything else is refused per file with a reason (`outside_archive_roots`, `unresolvable_path`) and left on disk.
 - A file already gone is reported as `missing`, not as an error — running a revert twice is not a failure to explain.
 - Deleting a `.msg` also removes its row from the index in the same step (`index_rows_removed` in the result), so `plan` offers the mail again right away instead of waiting for the next full scan to notice the file is gone. A file whose delete failed keeps its row — the file is still there, so the row is still correct.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,9 @@ The `NNN` prefix is meant to be browsable: opening a project folder and reading 
 }
 ```
 
-Only bundles that actually changed appear. `from`/`to` are `null` for a bundle that has no `.msg` (its files are all in `attachments`), so a consumer healing `.msg` paths simply has nothing to do for it. A folder that could **not** be renumbered is never an empty map in there — an empty map means "already in order" — it is listed under `renumber_refused` with its reason. The key is additive: `schema_version` is unchanged, and a consumer that does not know about it reads the rest of the document exactly as before.
+Only bundles that actually changed appear. `from`/`to` are `null` for a bundle that has no `.msg` (its files are all in `attachments`), so a consumer healing `.msg` paths simply has nothing to do for it.
+
+**This includes the same document's own `files` lists.** An `apply --renumber` result reports each mail's `files` under the names it was *written* with, and the renumber that ran afterwards may have moved some of them — so hand-an-`apply`-result-straight-to-`revert` needs the map applied to those paths first when the flag was used. Without `--renumber` the `files` are final, as they always were. A folder that could **not** be renumbered is never an empty map in there — an empty map means "already in order" — it is listed under `renumber_refused` with its reason. The key is additive: `schema_version` is unchanged, and a consumer that does not know about it reads the rest of the document exactly as before.
 
 ### Safety
 

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -13,11 +13,12 @@ flowchart TB
     MAINSCAN["main_scan.py\nheadless --no-ui, or opens ScanWindow"]
     MAINARCHIVE["main_archive.py\nopens ArchiveDialog directly"]
     MAINUI["main_ui.py\nopens LauncherApp (both buttons)"]
-    MAINBATCH["main_batch.py\nheadless plan / apply / revert,\none JSON document on stdout"]
+    MAINBATCH["main_batch.py\nheadless plan / apply / revert / renumber,\none JSON document on stdout"]
   end
 
   CONFIG["email_archiver/config.py\nload_config · get_archive_roots ·\nget_max_path_length · get_date_prefix_mode/_enabled ·\nget_outlook_archive_folder · get_outlook_category ·\nsetup_logging"]
   TEXT["email_archiver/text.py\nclean_subject — shared Re:/Fwd: stripping ·\nnormalize_message_id — one spelling of the\nMessage-ID for the scanner and the Outlook client"]
+  PATHS["email_archiver/paths.py\nis_within · resolve_under_roots · archive_roots —\nthe one archive.root_paths guard, shared by\nrevert's deletes and renumber's renames"]
 
   MAINSCAN --> CONFIG
   MAINARCHIVE --> CONFIG
@@ -74,7 +75,8 @@ flowchart TB
   ARCHIVER -->|writes .msg + attachments| ONEDRIVE
 
   subgraph batchflow["Batch mode data flow (headless, spawned by another app)"]
-    BATCH["batch.py\nplan · apply · revert —\npure orchestration, no COM, no tkinter.\nIdentity is the Internet Message-ID,\nnot EntryID (which a Move rewrites).\napply moves a re-acquired reference and\nfinishes an already-archived mail\nwithout writing anything"]
+    BATCH["batch.py\nplan · apply · revert · renumber —\npure orchestration, no COM, no tkinter.\nIdentity is the Internet Message-ID,\nnot EntryID (which a Move rewrites).\napply moves a re-acquired reference and\nfinishes an already-archived mail\nwithout writing anything"]
+    RENUMBER["renumber.py: renumber_folder\nbundles a number with its files, orders them by\nsent date, hands out contiguous numbers from the\nfolder's lowest, two-phase renames, returns the\nold-to-new map the consumer heals its paths from"]
   end
   CALLER["another local app (task-os)\nspawns the process with a timeout,\nreads one JSON document"] -->|subprocess| MAINBATCH
   MAINBATCH --> BATCH
@@ -85,3 +87,10 @@ flowchart TB
   BATCH -->|apply: per-mail date_prefix,\nskipped entirely for a reused mail| ARCHIVER
   BATCH -->|revert: delete only inside archive.root_paths| ONEDRIVE
   BATCH -->|revert: delete_by_path per deleted .msg| REPO
+  BATCH -->|renumber verb, or --renumber on apply / revert:\nonce per touched folder| RENUMBER
+  RENUMBER --> PATHS
+  BATCH --> PATHS
+  RENUMBER -->|split_sequence_prefix · sanitize_filename —\nthe naming rules stay the archiver's| ARCHIVER
+  RENUMBER -->|read_msg_facts: date, Message-ID, attachment names\nfor a .msg the index has not seen yet| SCANNER
+  RENUMBER -->|one listing pass, then os.rename per changed file| ONEDRIVE
+  RENUMBER -->|find_in_folder · update_path · delete_by_path| REPO

--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -58,8 +58,10 @@ logger = logging.getLogger(__name__)
 _OL_MSG_FORMAT = 3
 
 # Regexes to find the leading sequence number, in either filename form.
-# Dated is tried first since it is the more specific match.
-_RE_DATED_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2} - (\d{3}) - ")
+# Dated is tried first since it is the more specific match. Applied in exactly
+# one place — ``split_sequence_prefix`` below; every caller reads a filename
+# through that, so the naming rules stay owned by this module.
+_RE_DATED_PREFIX = re.compile(r"^(\d{4}-\d{2}-\d{2}) - (\d{3}) - ")
 _RE_UNDATED_PREFIX = re.compile(r"^(\d{3}) - ")
 
 # Maximum path length (in chars) the fitted filename must stay within. This is
@@ -86,7 +88,49 @@ class ArchiveResult:
 
 # ---------------------------------------------------------------- helpers ---
 
-def _sanitize_filename(text: str, max_len: int = 80) -> str:
+@dataclass(frozen=True)
+class SequencePrefix:
+    """A filename's leading sequence field, split into its parts.
+
+    ``"023 - report.pdf"`` → ``SequencePrefix("", "023", "report.pdf")`` and
+    ``"2026-03-14 - 023 - report.pdf"`` →
+    ``SequencePrefix("2026-03-14", "023", "report.pdf")``. Keeping the date
+    prefix as written (rather than a bool) is what lets a caller rewrite the
+    number without touching the form or re-deriving the date.
+    """
+
+    date_prefix: str  # "" for the undated form, "YYYY-MM-DD" otherwise
+    number: str       # the three digits exactly as written
+    rest: str         # everything after the prefix — the name itself
+
+    @property
+    def dated(self) -> bool:
+        return bool(self.date_prefix)
+
+    def with_number(self, number: str) -> str:
+        """The same filename carrying ``number`` instead, in the same form."""
+        head = f"{self.date_prefix} - " if self.date_prefix else ""
+        return f"{head}{number} - {self.rest}"
+
+
+def split_sequence_prefix(filename: str) -> SequencePrefix | None:
+    """Split ``filename``'s leading sequence field, or ``None`` when it has none.
+
+    Both forms are always recognised, dated first since it is the more specific
+    match — the same rule sequence allocation has always used, now shared with
+    :mod:`email_archiver.renumber` so the two can never drift apart on what
+    counts as a numbered file.
+    """
+    m = _RE_DATED_PREFIX.match(filename)
+    if m:
+        return SequencePrefix(m.group(1), m.group(2), filename[m.end():])
+    m = _RE_UNDATED_PREFIX.match(filename)
+    if m:
+        return SequencePrefix("", m.group(1), filename[m.end():])
+    return None
+
+
+def sanitize_filename(text: str, max_len: int = 80) -> str:
     """
     Remove characters illegal on Windows NTFS and truncate.
     Keeps ASCII letters/digits + a small set of safe punctuation.
@@ -166,14 +210,13 @@ def _scan_folder(folder_path: str) -> _FolderScan:
     dated = 0
     undated = 0
     for fname in files:
-        m = _RE_DATED_PREFIX.match(fname)
-        if m:
-            numbers.append(int(m.group(1)))
-            dated += 1
+        parsed = split_sequence_prefix(fname)
+        if parsed is None:
             continue
-        m = _RE_UNDATED_PREFIX.match(fname)
-        if m:
-            numbers.append(int(m.group(1)))
+        numbers.append(int(parsed.number))
+        if parsed.dated:
+            dated += 1
+        else:
             undated += 1
 
     next_num = (max(numbers) + 1) if numbers else 1
@@ -377,7 +420,7 @@ class EmailArchiver:
         subject: str,
         date_prefix: str | None,
     ) -> str:
-        safe_subject = _sanitize_filename(subject)
+        safe_subject = sanitize_filename(subject)
         filename = _fit_filename_to_path(
             folder_path, seq, safe_subject, ".msg",
             date_prefix=date_prefix, max_path=self._max_path,
@@ -442,7 +485,7 @@ class EmailArchiver:
 
             try:
                 original_name = attachment.FileName or f"attachment_{att_index}"
-                stem = _sanitize_filename(Path(original_name).stem, max_len=60)
+                stem = sanitize_filename(Path(original_name).stem, max_len=60)
                 suffix = Path(original_name).suffix.lower()
 
                 att_filename = _fit_filename_to_path(

--- a/email_archiver/batch.py
+++ b/email_archiver/batch.py
@@ -1,5 +1,5 @@
 """
-Headless batch mode: plan / apply / revert the whole Inbox with JSON I/O.
+Headless batch mode: plan / apply / revert / renumber, with JSON I/O.
 
 This module is what ``main_batch.py`` runs and what the tests exercise. It is
 pure orchestration over :class:`~email_archiver.outlook.client.OutlookClient`,
@@ -39,6 +39,13 @@ Design decisions:
   roots.** Anything resolving outside ``archive.root_paths`` is refused per
   file with a reason rather than deleted, so a malformed or hostile items file
   cannot reach the rest of the disk.
+- **Renumbering is opt-in and reported, never implied.** ``apply`` and
+  ``revert`` leave the sequence exactly as they always have unless
+  ``--renumber`` is passed; with it, each touched folder is renumbered once and
+  the document carries the old → new map under ``renumbered`` so the consumer
+  can heal the ``.msg`` paths it stored. A folder that could *not* be
+  renumbered is listed under ``renumber_refused`` with its reason — never an
+  empty map, which means something else entirely ("already in order").
 """
 from __future__ import annotations
 
@@ -50,7 +57,6 @@ from typing import Any
 
 from email_archiver.archiver.archiver import EmailArchiver, resolve_date_prefix_for_folder
 from email_archiver.config import (
-    get_archive_roots,
     get_outlook_archive_folder,
     get_outlook_category,
 )
@@ -58,6 +64,13 @@ from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRepository
 from email_archiver.engine.suggester import SuggestionEngine
 from email_archiver.outlook.client import EmailData, is_message_changed_error
+from email_archiver.paths import (
+    REFUSED_OUTSIDE_ROOTS,
+    REFUSED_UNRESOLVABLE,
+    archive_roots as _archive_roots,
+    resolve_under_roots as _resolve_under_roots,
+)
+from email_archiver.renumber import RenumberResult, renumber_folder
 from email_archiver.text import normalize_message_id
 
 logger = logging.getLogger(__name__)
@@ -87,9 +100,10 @@ ERROR_MOVE_FAILED = "move_failed"               # files are on disk, mail is not
 # looks untouched in Outlook.
 ERROR_CATEGORY_FAILED = "category_failed"
 
-# Per-file outcomes in a revert result.
-REFUSED_OUTSIDE_ROOTS = "outside_archive_roots"
-REFUSED_UNRESOLVABLE = "unresolvable_path"
+# The per-file outcomes in a revert result — REFUSED_OUTSIDE_ROOTS and
+# REFUSED_UNRESOLVABLE — are imported above from `paths`, which owns the
+# archive-root guard now that `renumber` applies it too. They stay readable as
+# `batch.REFUSED_*`, which is where consumers and tests look for them.
 
 # Which reference finished an `apply` move, reported as the result's
 # `move_via`. Three genuinely different stories about the same mail, and the
@@ -173,52 +187,6 @@ def _mail_dict(mail: Any) -> dict[str, Any]:
     }
 
 
-def _is_within(child: Path, root: Path) -> bool:
-    """Whether ``child`` is ``root`` or lives underneath it.
-
-    Compared through ``os.path.normcase`` rather than
-    ``Path.is_relative_to`` alone: on Windows the two paths routinely differ in
-    case (the config spells a root one way, ``resolve()`` another) and a
-    case-sensitive comparison would refuse a file that is genuinely inside the
-    archive. The trailing separator is what stops ``C:\\Archive`` from matching
-    ``C:\\ArchiveOther``.
-    """
-    child_s = os.path.normcase(str(child))
-    root_s = os.path.normcase(str(root))
-    if child_s == root_s:
-        return True
-    return child_s.startswith(root_s.rstrip("\\/") + os.sep)
-
-
-def _resolve_under_roots(
-    raw_path: str, roots: list[Path]
-) -> tuple[Path | None, str | None]:
-    """Resolve a path and require it to sit under one of the archive roots.
-
-    Returns ``(path, None)`` when it does, ``(None, reason)`` when it does not.
-    The refusal is deliberately not an exception: ``revert`` reports it per file
-    and carries on with the rest of the bundle.
-    """
-    try:
-        resolved = Path(raw_path).resolve()
-    except (OSError, ValueError):
-        return None, REFUSED_UNRESOLVABLE
-    for root in roots:
-        if _is_within(resolved, root):
-            return resolved, None
-    return None, REFUSED_OUTSIDE_ROOTS
-
-
-def _archive_roots(cfg: dict[str, Any]) -> list[Path]:
-    resolved: list[Path] = []
-    for raw in get_archive_roots(cfg):
-        try:
-            resolved.append(Path(raw).resolve())
-        except (OSError, ValueError):
-            logger.warning("Ignoring unresolvable archive root: %r", raw)
-    return resolved
-
-
 def _envelope(verb: str, cfg: dict[str, Any]) -> dict[str, Any]:
     return {
         "verb": verb,
@@ -227,6 +195,57 @@ def _envelope(verb: str, cfg: dict[str, Any]) -> dict[str, Any]:
         "archive_folder": get_outlook_archive_folder(cfg),
         "category": get_outlook_category(cfg),
     }
+
+
+def _unique_folders(paths: list[str]) -> list[str]:
+    """The distinct folders in ``paths``, first spelling wins.
+
+    Deduplicated case-insensitively because Windows hands the same folder back
+    spelled several ways, and renumbering one folder twice in a run would
+    reorder what the first pass just fixed.
+    """
+    seen: set[str] = set()
+    folders: list[str] = []
+    for raw in paths:
+        folder = os.path.normpath(raw)
+        key = os.path.normcase(folder)
+        if key in seen:
+            continue
+        seen.add(key)
+        folders.append(folder)
+    return folders
+
+
+def _renumber_folders(
+    cfg: dict[str, Any], repo: EmailRepository, folders: list[str]
+) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
+    """Renumber each touched folder once; return ``(renumbered, refused)``.
+
+    ``renumbered`` is the map a consumer heals its stored paths from, keyed by
+    folder. A folder that could not be renumbered at all is **not** an empty
+    map in there — an empty map means "already in order", which is a different
+    fact — it goes into ``refused`` with its reason.
+    """
+    roots = _archive_roots(cfg)
+    renumbered: dict[str, list[dict[str, Any]]] = {}
+    refused: list[dict[str, Any]] = []
+
+    for folder in folders:
+        try:
+            result = renumber_folder(folder, repo, roots)
+        except Exception as exc:  # one folder's failure is not the run's
+            logger.exception("Renumbering %r failed", folder)
+            refused.append({
+                "folder_path": folder,
+                "reason": f"{type(exc).__name__}: {exc}",
+            })
+            continue
+        if result.refused:
+            refused.append({"folder_path": folder, "reason": result.refused})
+            continue
+        renumbered[result.folder_path] = result.renamed
+
+    return renumbered, refused
 
 
 def error_document(verb: str, code: str, message: str) -> dict[str, Any]:
@@ -343,6 +362,8 @@ def apply(
     client: Any,
     cfg: dict[str, Any],
     decisions: list[dict[str, Any]],
+    *,
+    renumber: bool = False,
 ) -> dict[str, Any]:
     """Archive each decided mail, move it out of the Inbox and tag it.
 
@@ -361,6 +382,13 @@ def apply(
 
     Whatever happens to one mail, the next is still attempted; the per-mail
     ``error`` says what went wrong and ``files`` says what is already on disk.
+
+    With ``renumber`` on, every destination folder this run put a bundle in is
+    renumbered once afterwards — a mail older than the folder's newest file
+    took ``max + 1`` on the way in, and this is what puts it back in date order
+    — and the document carries the old → new map per folder under
+    ``renumbered``. Off (the default), the verb behaves exactly as before and
+    neither key appears.
     """
     archive_folder = get_outlook_archive_folder(cfg)
     category = get_outlook_category(cfg)
@@ -373,10 +401,16 @@ def apply(
             results.append(
                 _apply_one(client, cfg, repo, raw, archive_folder, category)
             )
+        doc = _envelope("apply", cfg)
+        if renumber:
+            # Only a folder this run actually wrote into, and only once each.
+            doc["renumbered"], doc["renumber_refused"] = _renumber_folders(
+                cfg, repo,
+                _unique_folders([r["folder_path"] for r in results if r["files"]]),
+            )
     finally:
         conn.close()
 
-    doc = _envelope("apply", cfg)
     applied = sum(1 for r in results if r["ok"])
     doc["counts"] = {
         "requested": len(results),
@@ -607,6 +641,8 @@ def revert(
     client: Any,
     cfg: dict[str, Any],
     items: list[dict[str, Any]],
+    *,
+    renumber: bool = False,
 ) -> dict[str, Any]:
     """Delete the listed archive files and put each mail back in the Inbox.
 
@@ -627,6 +663,11 @@ def revert(
     that no longer exists instead of offering it again. A file whose delete
     failed leaves its row alone — the file is still there, so the row is
     still correct. Reported per result as ``index_rows_removed``.
+
+    With ``renumber`` on, every folder this run deleted a file from is
+    renumbered once afterwards, closing the gap the delete left, and the
+    document carries the old → new map per folder under ``renumbered``. Off
+    (the default), the verb behaves exactly as before and neither key appears.
     """
     archive_folder = get_outlook_archive_folder(cfg)
     category = get_outlook_category(cfg)
@@ -660,10 +701,19 @@ def revert(
             conn.commit()
 
             results.append(_finish_revert_item(client, archive_folder, category, result, message_id))
+        doc = _envelope("revert", cfg)
+        if renumber:
+            # The source folders: a gap only exists where a file really went.
+            doc["renumbered"], doc["renumber_refused"] = _renumber_folders(
+                cfg, repo,
+                _unique_folders([
+                    os.path.dirname(path)
+                    for r in results for path in r["deleted"]
+                ]),
+            )
     finally:
         conn.close()
 
-    doc = _envelope("revert", cfg)
     reverted = sum(1 for r in results if r["ok"])
     doc["counts"] = {
         "requested": len(results),
@@ -722,3 +772,54 @@ def _finish_revert_item(
 
     result["ok"] = not result["refused"] and not result["file_errors"]
     return result
+
+
+# --------------------------------------------------------------- renumber ---
+
+def renumber(
+    cfg: dict[str, Any], folder_path: str, *, dry_run: bool = False
+) -> dict[str, Any]:
+    """Renumber one folder and return the old → new map.
+
+    The only verb that touches neither Outlook nor COM: it reads a folder
+    listing and the index, and renames files. ``dry_run`` reports exactly the
+    same map without changing anything on disk.
+
+    The map is reported under the same ``renumbered`` key ``apply --renumber``
+    and ``revert --renumber`` use, so a consumer healing its stored ``.msg``
+    paths reads one shape whichever verb produced it.
+    """
+    normalised = os.path.normpath(folder_path)
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    try:
+        result = renumber_folder(
+            folder_path, repo, _archive_roots(cfg), dry_run=dry_run
+        )
+    except Exception as exc:
+        # Never a traceback over an empty stdout: this process's contract is one
+        # JSON document, in one shape, whatever happened. A run that stopped
+        # part-way is refused with its reason and reports no map — a map the
+        # disk may not match is worse to hand a consumer than none at all.
+        logger.exception("Renumbering %r failed", normalised)
+        result = RenumberResult(
+            folder_path=normalised,
+            dry_run=dry_run,
+            refused=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        conn.close()
+
+    doc = _envelope("renumber", cfg)
+    doc["dry_run"] = result.dry_run
+    doc["folder_path"] = result.folder_path
+    doc["first_number"] = result.first_number
+    doc["last_number"] = result.last_number
+    doc["counts"] = result.counts()
+    doc["skipped"] = result.skipped
+    doc["renumbered"] = {} if result.refused else {result.folder_path: result.renamed}
+    doc["renumber_refused"] = (
+        [{"folder_path": result.folder_path, "reason": result.refused}]
+        if result.refused else []
+    )
+    return doc

--- a/email_archiver/database/repository.py
+++ b/email_archiver/database/repository.py
@@ -7,6 +7,7 @@ upper layers never import sqlite3 directly.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import sqlite3
 from dataclasses import dataclass, field
@@ -155,6 +156,32 @@ class EmailRepository:
         self._conn.execute("DROP TABLE tmp_known_paths")
         return cur.rowcount
 
+    def update_path(self, old_path: str, new_path: str) -> int:
+        """Point one index row at a renamed file. Returns rows updated.
+
+        Called by :func:`email_archiver.renumber.renumber_folder` after it
+        renames a ``.msg``: the row still describes the right mail, only its
+        ``file_path``/``filename`` moved, so re-indexing it would be both
+        wasteful and lossy (a fresh row would drop ``indexed_at``). ``file_mtime``
+        is deliberately left alone — a rename does not change it, so the next
+        incremental scan still skips the file. Caller commits (or uses
+        :meth:`commit`).
+        """
+        cur = self._conn.execute(
+            "UPDATE emails SET file_path = ?, filename = ? WHERE file_path = ?",
+            (new_path, os.path.basename(new_path), old_path),
+        )
+        return cur.rowcount
+
+    def commit(self) -> None:
+        """Commit the pending writes on the wrapped connection.
+
+        Exists so a caller holding only a repository — ``renumber_folder``,
+        which must land a folder's renames and its index rows together — does
+        not have to be handed the raw connection as well.
+        """
+        self._conn.commit()
+
     def delete_by_path(self, file_path: str) -> int:
         """Remove the index row for one file, if any. Returns rows deleted.
 
@@ -195,6 +222,41 @@ class EmailRepository:
             (message_id,),
         ).fetchone()
         return row["file_path"] if row else None
+
+    def find_in_folder(self, folder_path: str) -> list[EmailRecord]:
+        """Every indexed row filed directly in ``folder_path``.
+
+        Matched ``COLLATE NOCASE`` on purpose: Windows spells the same folder
+        several ways (the config's casing, ``Path.resolve()``'s canonical
+        casing, whatever a caller typed) and the index holds whichever spelling
+        the scan walked in with. A case-sensitive match would come back empty
+        and be indistinguishable from "this folder has never been indexed" —
+        which for a renumber means silently not updating any row.
+
+        The rows come back carrying the ``file_path`` **as stored**, so a caller
+        updating one writes against the spelling the index actually holds.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM emails WHERE folder_path = ? COLLATE NOCASE",
+            (folder_path,),
+        ).fetchall()
+        return [
+            EmailRecord(
+                id=row["id"],
+                file_path=row["file_path"],
+                folder_path=row["folder_path"],
+                filename=row["filename"],
+                subject=row["subject"] or "",
+                sender=row["sender"] or "",
+                recipients=row["recipients"] or "",
+                date_sent=row["date_sent"] or "",
+                body_preview=row["body_preview"] or "",
+                file_mtime=row["file_mtime"],
+                flag_status=row["flag_status"],
+                message_id=row["message_id"] or "",
+            )
+            for row in rows
+        ]
 
     def count_emails(self) -> int:
         row = self._conn.execute("SELECT COUNT(*) FROM emails").fetchone()

--- a/email_archiver/paths.py
+++ b/email_archiver/paths.py
@@ -1,0 +1,73 @@
+"""
+Archive-root path safety, in one place.
+
+Two different operations write to (or rename inside) the archive tree —
+``batch.revert``'s deletes and ``renumber``'s renames — and both must refuse
+anything that resolves outside the configured ``archive.root_paths``. That
+guard is a safety primitive, so it is defined exactly once here rather than
+copied into each module: a second spelling of "is this inside the archive?" is
+a second chance to get it wrong.
+
+The refusal is deliberately not an exception. ``revert`` reports it per file
+and carries on with the rest of the bundle; ``renumber`` reports it per folder
+and leaves that folder untouched.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from email_archiver.config import get_archive_roots
+
+logger = logging.getLogger(__name__)
+
+# Why a path was refused.
+REFUSED_OUTSIDE_ROOTS = "outside_archive_roots"
+REFUSED_UNRESOLVABLE = "unresolvable_path"
+
+
+def is_within(child: Path, root: Path) -> bool:
+    """Whether ``child`` is ``root`` or lives underneath it.
+
+    Compared through ``os.path.normcase`` rather than ``Path.is_relative_to``
+    alone: on Windows the two paths routinely differ in case (the config spells
+    a root one way, ``resolve()`` another) and a case-sensitive comparison
+    would refuse a file that is genuinely inside the archive. The trailing
+    separator is what stops ``C:\\Archive`` from matching ``C:\\ArchiveOther``.
+    """
+    child_s = os.path.normcase(str(child))
+    root_s = os.path.normcase(str(root))
+    if child_s == root_s:
+        return True
+    return child_s.startswith(root_s.rstrip("\\/") + os.sep)
+
+
+def resolve_under_roots(
+    raw_path: str, roots: list[Path]
+) -> tuple[Path | None, str | None]:
+    """Resolve a path and require it to sit under one of the archive roots.
+
+    Returns ``(path, None)`` when it does, ``(None, reason)`` when it does not.
+    """
+    try:
+        resolved = Path(raw_path).resolve()
+    except (OSError, ValueError):
+        return None, REFUSED_UNRESOLVABLE
+    for root in roots:
+        if is_within(resolved, root):
+            return resolved, None
+    return None, REFUSED_OUTSIDE_ROOTS
+
+
+def archive_roots(cfg: dict[str, Any]) -> list[Path]:
+    """The configured archive roots, resolved; an unresolvable one is dropped
+    with a warning rather than silently widening or narrowing the guard."""
+    resolved: list[Path] = []
+    for raw in get_archive_roots(cfg):
+        try:
+            resolved.append(Path(raw).resolve())
+        except (OSError, ValueError):
+            logger.warning("Ignoring unresolvable archive root: %r", raw)
+    return resolved

--- a/email_archiver/renumber.py
+++ b/email_archiver/renumber.py
@@ -448,12 +448,16 @@ def _rename(folder: str, moves: list[_Move]) -> None:
                 "folder; nothing was renamed"
             )
 
-    for move in moves:
-        os.rename(os.path.join(folder, move.old), os.path.join(folder, move.temp))
     try:
+        for move in moves:
+            os.rename(os.path.join(folder, move.old), os.path.join(folder, move.temp))
         for move in moves:
             os.rename(os.path.join(folder, move.temp), os.path.join(folder, move.new))
     except OSError:
+        # Either phase. Whichever one stopped, the recovery is the same and it
+        # needs the list: a file under a placeholder is invisible to every
+        # other part of this app, so the next occurrence has to be
+        # diagnosable from the log alone.
         left = [m.temp for m in moves if os.path.exists(os.path.join(folder, m.temp))]
         logger.error(
             "Renumber stopped part-way; %d file(s) are still under a placeholder "
@@ -518,6 +522,29 @@ def _reindex(
     return updated, dropped
 
 
+def _warn_if_unindexed(
+    folder: str, groups: dict[str, dict[str, list[str]]], indexed: dict[str, Any]
+) -> None:
+    """Say so out loud when the index has nothing for a folder full of mail.
+
+    ``find_in_folder`` matches ``COLLATE NOCASE``, which covers the ways Windows
+    respells the same path, but not every way a folder can be named (a mapped
+    drive letter, a UNC spelling, a junction). A lookup that comes back empty
+    then looks exactly like "this folder was never scanned", and the renumber
+    would go on to read every date off disk and update no rows at all — a
+    quietly incomplete result. Reported as its own fact rather than folded into
+    a successful run.
+    """
+    msgs = sum(len(group["msgs"]) for group in groups.values())
+    if msgs and not indexed:
+        logger.warning(
+            "The index holds no row for any of the %d mail(s) in %r. Dates will "
+            "be read from the files and no index row will be updated — if this "
+            "folder *has* been scanned, the path is spelled differently there.",
+            msgs, folder,
+        )
+
+
 # ------------------------------------------------------------------ entry ---
 
 def renumber_folder(
@@ -561,6 +588,7 @@ def renumber_folder(
         return result
 
     indexed = {r.filename.lower(): r for r in repo.find_in_folder(normalised)}
+    _warn_if_unindexed(normalised, groups, indexed)
     ordered = _order(_build_bundles(normalised, groups, prefixes, indexed))
 
     base = min(int(number) for number in groups)

--- a/email_archiver/renumber.py
+++ b/email_archiver/renumber.py
@@ -1,0 +1,603 @@
+"""
+Renumber an archive folder so its sequence numbers read as the mails' order.
+
+The ``NNN`` in ``NNN - name.ext`` is meant to be browsable: opening a project
+folder in Explorer and reading down the list should be reading the thread in
+the order it happened. Two things break that, and neither is a bug in how a
+single mail is archived:
+
+- ``batch.revert`` deletes a bundle and leaves a hole in the sequence;
+- ``batch.apply`` always allocates ``max + 1``, so a mail filed into a folder
+  after the fact takes the highest number even when it is older than what is
+  already there.
+
+``renumber_folder`` is the repair: order the folder's numbered bundles by sent
+date, hand out contiguous numbers from the folder's lowest existing one, and
+return the old → new map so a consumer that stored ``.msg`` paths can heal its
+own references.
+
+Design decisions:
+
+- **The unit is a bundle, not a file.** A number and every file carrying it
+  move together, so an email never parts company with its attachments. A
+  number that carries no ``.msg`` at all (an attachment whose mail was deleted
+  by hand, a document filed into the sequence) is still a bundle: it holds its
+  slot and its number moves with everything else, because leaving it behind
+  would park it on a number that now belongs to a different mail.
+- **An unknown date keeps its position.** A bundle with no readable date — no
+  ``.msg``, or one whose date will not parse — inherits the date of the bundle
+  before it and is ordered stably after it. It stays where the owner put it
+  instead of being swept to one end of the folder.
+- **The base is the folder's lowest existing number, not 001.** A "part 2"
+  folder that starts at 079 keeps starting at 079: its numbers continue another
+  folder's sequence, and renumbering it from 001 would destroy that.
+- **Two mails on one number are split by date, and their attachments are
+  matched to the right one.** Which files on a shared number belong to which
+  mail cannot be read off the filenames, so each candidate ``.msg`` is asked
+  what attachments it carries and the on-disk names are matched against that.
+  An attachment that still cannot be placed follows the earlier mail, and the
+  result says so — a guess that is reported is recoverable, a silent one is not.
+- **Renames go through a temporary name first.** Closing a gap shifts a run of
+  bundles down by one, so a file's target name is very often the name of the
+  file next to it. Every changing file is moved to a same-length ``~XX``
+  placeholder first and to its final name second, so no rename ever lands on a
+  name that is still occupied. Same length on purpose: these paths sit near
+  Windows' MAX_PATH and a longer temporary name could fail to be created at all.
+- **Only files that actually change are touched.** A OneDrive-backed folder is
+  listed once and a bundle whose number does not move is not renamed, not
+  re-read, and not re-indexed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from email_archiver.archiver.archiver import (
+    SequencePrefix,
+    sanitize_filename,
+    split_sequence_prefix,
+)
+from email_archiver.database.repository import EmailRepository
+from email_archiver.paths import resolve_under_roots
+from email_archiver.scanner.scanner import read_msg_facts
+
+logger = logging.getLogger(__name__)
+
+_MSG_SUFFIX = ".msg"
+
+# Why a whole folder was refused. The path reasons come from `paths`; this one
+# is renumber's own.
+REFUSED_UNREADABLE = "unreadable_folder"
+
+# How an attachment on a shared number was placed, reported per split bundle.
+PLACED_BY_MSG = "matched_to_msg"        # the .msg lists it as its attachment
+PLACED_BY_FALLBACK = "assigned_to_first"  # nothing matched; earliest mail took it
+
+# Placeholder numbers for the first rename phase. Exactly three characters, so
+# a path that fits today still fits mid-rename, and starting with `~` so a
+# placeholder can never be mistaken for a real sequence number.
+_TEMP_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+_MAX_TEMP = len(_TEMP_ALPHABET) ** 2
+
+# The sort key an unknown date gets when nothing before it has one either:
+# it stays at the front of the folder, which is where it already is.
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
+class RenumberError(RuntimeError):
+    """A folder that could not be renumbered safely, mid-flight."""
+
+
+# ----------------------------------------------------------------- types ----
+
+@dataclass
+class RenumberResult:
+    """What one folder's renumber did — or would do, under ``dry_run``."""
+
+    folder_path: str
+    dry_run: bool = False
+    # Set when nothing was attempted at all: the folder is outside the archive
+    # roots, unresolvable, or unreadable. Never folded into "renamed nothing".
+    refused: str | None = None
+    # The old → new map, one entry per bundle whose number changed.
+    renamed: list[dict[str, Any]] = field(default_factory=list)
+    # Filenames with no sequence prefix — left exactly as they are.
+    skipped: list[str] = field(default_factory=list)
+    bundles: int = 0
+    unchanged: int = 0
+    files_renamed: int = 0
+    index_rows_updated: int = 0
+    # Rows that described a file no longer at that name and whose name a rename
+    # has now given to a different mail. Counted separately from the updates:
+    # "the index followed the renames" and "the index was also wrong" are two
+    # facts, and folding the second into the first hides it.
+    index_rows_dropped: int = 0
+    first_number: str = ""
+    last_number: str = ""
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "bundles": self.bundles,
+            "renamed": len(self.renamed),
+            "unchanged": self.unchanged,
+            "files_renamed": self.files_renamed,
+            "skipped": len(self.skipped),
+            "index_rows_updated": self.index_rows_updated,
+            "index_rows_dropped": self.index_rows_dropped,
+        }
+
+
+@dataclass
+class _Bundle:
+    """One sequence number's worth of files, with the mail that anchors it."""
+
+    number: str
+    position: int
+    msg: str | None = None                       # filename, not a path
+    attachments: list[str] = field(default_factory=list)
+    prefixes: dict[str, SequencePrefix] = field(default_factory=dict)
+    message_id: str = ""
+    sent: datetime | None = None
+    sort_key: datetime = _EPOCH
+    placement: str = ""                          # only set on a split bundle
+
+    def files(self) -> list[str]:
+        return ([self.msg] if self.msg else []) + self.attachments
+
+
+@dataclass
+class _Move:
+    """One file's two-phase rename."""
+
+    old: str
+    temp: str
+    new: str
+    is_msg: bool
+
+
+# --------------------------------------------------------------- reading ----
+
+def _parse_folder(
+    folder: str,
+) -> tuple[dict[str, dict[str, list[str]]], dict[str, SequencePrefix], list[str]]:
+    """One listing pass: numbered files grouped by number, plus the rest.
+
+    Returns ``(groups, prefixes, skipped)`` where ``groups`` maps a sequence
+    number to its ``msgs``/``others`` filenames, ``prefixes`` maps every
+    numbered filename to its parsed prefix, and ``skipped`` holds the filenames
+    that carry no sequence number.
+    """
+    groups: dict[str, dict[str, list[str]]] = {}
+    prefixes: dict[str, SequencePrefix] = {}
+    skipped: list[str] = []
+
+    for name in sorted(os.listdir(folder)):
+        if not os.path.isfile(os.path.join(folder, name)):
+            continue
+        parsed = split_sequence_prefix(name)
+        if parsed is None:
+            skipped.append(name)
+            continue
+        prefixes[name] = parsed
+        bucket = groups.setdefault(parsed.number, {"msgs": [], "others": []})
+        key = "msgs" if name.lower().endswith(_MSG_SUFFIX) else "others"
+        bucket[key].append(name)
+
+    return groups, prefixes, skipped
+
+
+def _parse_sent(raw: str) -> datetime | None:
+    """An indexed ``date_sent`` as a comparable, timezone-aware datetime.
+
+    Naive values are read as local time — that is what the scanner wrote, and
+    comparing a naive value against an aware one raises rather than mis-sorts,
+    so this is the one place the two can meet.
+    """
+    if not raw:
+        return None
+    try:
+        value = datetime.fromisoformat(raw)
+    except ValueError:
+        logger.debug("Unparseable date_sent %r; treating it as unknown", raw)
+        return None
+    return value if value.tzinfo is not None else value.astimezone()
+
+
+@dataclass
+class _MsgFacts:
+    sent: datetime | None
+    message_id: str
+    attachment_names: tuple[str, ...]
+
+
+def _facts_for(
+    folder: str,
+    name: str,
+    indexed: dict[str, Any],
+    *,
+    need_attachments: bool = False,
+) -> _MsgFacts:
+    """What is known about one ``.msg``: its sent date, id and attachments.
+
+    The index answers first — it is already read and costs nothing. The file
+    itself is opened only when the index cannot answer: no row (archived since
+    the last scan), no usable date, or an attachment list is needed to place a
+    shared number's files.
+    """
+    record = indexed.get(name.lower())
+    sent = _parse_sent(record.date_sent) if record is not None else None
+    message_id = (record.message_id or "") if record is not None else ""
+    attachment_names: tuple[str, ...] = ()
+
+    if sent is None or need_attachments:
+        facts = read_msg_facts(os.path.join(folder, name))
+        if facts is not None:
+            sent = sent or _parse_sent(facts.date_sent)
+            message_id = message_id or facts.message_id
+            attachment_names = facts.attachment_names
+
+    if sent is None:
+        logger.info("No sent date for %r; it keeps its position in the folder", name)
+    return _MsgFacts(sent, message_id, attachment_names)
+
+
+# -------------------------------------------------------------- bundling ----
+
+def _match_key(stem: str) -> str:
+    """A filename stem reduced to what two spellings of it have in common.
+
+    The archiver sanitises an attachment's name, lowercases its suffix, cuts
+    the stem to fit MAX_PATH (leaving a trailing ``...``) and appends ``_2`` on
+    a collision, so the name on disk is rarely the name the mail carries. Both
+    sides go through this before they are compared.
+    """
+    return sanitize_filename(stem, max_len=60).casefold().rstrip("._ ")
+
+
+# Below this, a shared prefix says nothing: "re" and "report.pdf" are not the
+# same attachment, and one of the two names is usually a MAX_PATH truncation.
+_MIN_PREFIX_MATCH = 4
+
+
+def _claims(stem: str, keys: set[str]) -> bool:
+    """Whether a mail carrying ``keys`` plausibly owns the file stem ``stem``."""
+    if not stem:
+        return False
+    if stem in keys:
+        return True
+    return any(
+        len(key) >= _MIN_PREFIX_MATCH
+        and len(stem) >= _MIN_PREFIX_MATCH
+        and (stem.startswith(key) or key.startswith(stem))
+        for key in keys
+    )
+
+
+def _place_attachments(
+    others: list[str],
+    prefixes: dict[str, SequencePrefix],
+    candidates: list[tuple[str, _MsgFacts]],
+) -> tuple[dict[str, list[str]], str]:
+    """Split one number's non-``.msg`` files between the mails sharing it.
+
+    Each candidate mail is asked which attachments it carries; a file on disk
+    goes to the mail that names it. Anything still unplaced goes to the first
+    (earliest) mail, and the caller is told that is what happened — the
+    alternative, leaving it on a number that is about to belong to someone
+    else, is worse and silent.
+    """
+    owned: dict[str, list[str]] = {name: [] for name, _ in candidates}
+    known = {
+        name: {_match_key(Path(att).stem) for att in facts.attachment_names}
+        for name, facts in candidates
+    }
+    placement = PLACED_BY_MSG
+
+    for other in others:
+        stem = _match_key(Path(prefixes[other].rest).stem)
+        owner = next(
+            (name for name, _ in candidates if _claims(stem, known[name])), None
+        )
+        if owner is None:
+            owner = candidates[0][0]
+            placement = PLACED_BY_FALLBACK
+            logger.info(
+                "No mail on this number claims %r; it follows the earlier mail",
+                other,
+            )
+        owned[owner].append(other)
+
+    return owned, placement
+
+
+def _build_bundles(
+    folder: str,
+    groups: dict[str, dict[str, list[str]]],
+    prefixes: dict[str, SequencePrefix],
+    indexed: dict[str, Any],
+) -> list[_Bundle]:
+    """Every numbered bundle in the folder, in its current on-disk order."""
+    bundles: list[_Bundle] = []
+
+    for number in sorted(groups, key=int):
+        msgs = groups[number]["msgs"]
+        others = groups[number]["others"]
+
+        if not msgs:
+            # No mail anchors this number. It still holds a slot: its files
+            # would otherwise end up sharing a number with a different mail.
+            bundles.append(_Bundle(
+                number=number,
+                position=len(bundles),
+                attachments=list(others),
+                prefixes={n: prefixes[n] for n in others},
+            ))
+            continue
+
+        facts = {
+            name: _facts_for(folder, name, indexed, need_attachments=len(msgs) > 1)
+            for name in msgs
+        }
+        ordered = sorted(msgs, key=lambda n: (facts[n].sent or _EPOCH, n))
+
+        if len(ordered) == 1:
+            owned = {ordered[0]: list(others)}
+            placement = ""
+        else:
+            logger.info(
+                "Sequence number %s carries %d mails; splitting them by date",
+                number, len(ordered),
+            )
+            owned, placement = _place_attachments(
+                others, prefixes, [(n, facts[n]) for n in ordered]
+            )
+
+        for name in ordered:
+            files = [name, *owned[name]]
+            bundles.append(_Bundle(
+                number=number,
+                position=len(bundles),
+                msg=name,
+                attachments=list(owned[name]),
+                prefixes={n: prefixes[n] for n in files},
+                message_id=facts[name].message_id,
+                sent=facts[name].sent,
+                placement=placement if len(ordered) > 1 else "",
+            ))
+
+    return bundles
+
+
+def _order(bundles: list[_Bundle]) -> list[_Bundle]:
+    """Chronological order, with an undated bundle keeping its place.
+
+    An undated bundle inherits the date of the last dated bundle before it, so
+    a stable sort leaves it sitting exactly where it sits now — right after
+    that neighbour — rather than at one end of the folder.
+    """
+    carried = _EPOCH
+    for bundle in bundles:
+        if bundle.sent is not None:
+            carried = bundle.sent
+        bundle.sort_key = carried
+    return sorted(bundles, key=lambda b: (b.sort_key, b.position))
+
+
+# --------------------------------------------------------------- renaming ---
+
+def _temp_number(index: int) -> str:
+    """A three-character placeholder number that no real file can carry."""
+    if index >= _MAX_TEMP:
+        raise RenumberError(
+            f"more than {_MAX_TEMP} files to rename in one folder; "
+            "renumber it in smaller pieces"
+        )
+    high, low = divmod(index, len(_TEMP_ALPHABET))
+    return f"~{_TEMP_ALPHABET[high]}{_TEMP_ALPHABET[low]}"
+
+
+def _plan(
+    folder: str, ordered: list[_Bundle], base: int
+) -> tuple[list[_Move], list[dict[str, Any]], int]:
+    """The renames to run and the map to report, for one ordered folder."""
+    moves: list[_Move] = []
+    mapped: list[dict[str, Any]] = []
+    unchanged = 0
+
+    for offset, bundle in enumerate(ordered):
+        number = f"{base + offset:03d}"
+        if number == bundle.number:
+            unchanged += 1
+            continue
+
+        entry: dict[str, Any] = {
+            "from": None,
+            "to": None,
+            "message_id": bundle.message_id,
+            "attachments": [],
+        }
+        for name in bundle.files():
+            new_name = bundle.prefixes[name].with_number(number)
+            temp_name = bundle.prefixes[name].with_number(_temp_number(len(moves)))
+            is_msg = name == bundle.msg
+            moves.append(_Move(old=name, temp=temp_name, new=new_name, is_msg=is_msg))
+            old_path = os.path.join(folder, name)
+            new_path = os.path.join(folder, new_name)
+            if is_msg:
+                entry["from"], entry["to"] = old_path, new_path
+            else:
+                entry["attachments"].append([old_path, new_path])
+        if bundle.placement:
+            entry["attachments_placed"] = bundle.placement
+        mapped.append(entry)
+
+    return moves, mapped, unchanged
+
+
+def _rename(folder: str, moves: list[_Move]) -> None:
+    """Run the two phases, refusing to start if a placeholder is taken."""
+    for move in moves:
+        temp_path = os.path.join(folder, move.temp)
+        if os.path.exists(temp_path):
+            raise RenumberError(
+                f"the placeholder name {move.temp!r} is already taken in this "
+                "folder; nothing was renamed"
+            )
+
+    for move in moves:
+        os.rename(os.path.join(folder, move.old), os.path.join(folder, move.temp))
+    try:
+        for move in moves:
+            os.rename(os.path.join(folder, move.temp), os.path.join(folder, move.new))
+    except OSError:
+        left = [m.temp for m in moves if os.path.exists(os.path.join(folder, m.temp))]
+        logger.error(
+            "Renumber stopped part-way; %d file(s) are still under a placeholder "
+            "name in this folder: %s", len(left), left,
+        )
+        raise
+
+
+def _sibling(stored_path: str, name: str) -> str:
+    """``name`` in the folder ``stored_path`` is in — the index's spelling of it,
+    not this caller's spelling of the same folder."""
+    return os.path.join(os.path.dirname(stored_path), name)
+
+
+def _reindex(
+    moves: list[_Move], indexed: dict[str, Any], repo: EmailRepository
+) -> tuple[int, int]:
+    """Follow the renames in the index. Returns ``(rows updated, rows dropped)``.
+
+    Two phases, for the same reason the files themselves go through a
+    placeholder: a row's target path is very often another row's current path,
+    and ``emails.file_path`` is UNIQUE — updating them one by one in bundle
+    order hits that constraint the moment a run shifts down by one. (Observed
+    the first time this ran against a real folder: the files were renamed and
+    the whole index update rolled back.)
+
+    A row still sitting on a name a rename is about to take, which is not
+    itself one of the rows being moved, cannot be describing a file that is
+    still there — nothing on disk was at that name (a target never collides
+    with a file that stays put), so the row is stale and is dropped rather than
+    left to collide or to point at somebody else's mail.
+    """
+    msg_moves = [move for move in moves if move.is_msg]
+    sources = {move.old.lower() for move in msg_moves}
+    pairs = [
+        (indexed[move.old.lower()], move)
+        for move in msg_moves
+        if move.old.lower() in indexed
+    ]
+
+    dropped = 0
+    for move in msg_moves:
+        stale = indexed.get(move.new.lower())
+        if stale is not None and move.new.lower() not in sources:
+            logger.info(
+                "Dropping the index row for %r: that name now belongs to a "
+                "different mail and the file it described is gone", move.new,
+            )
+            dropped += repo.delete_by_path(stale.file_path)
+
+    for record, move in pairs:
+        repo.update_path(record.file_path, _sibling(record.file_path, move.temp))
+    updated = 0
+    for record, move in pairs:
+        updated += repo.update_path(
+            _sibling(record.file_path, move.temp),
+            _sibling(record.file_path, move.new),
+        )
+
+    if updated or dropped:
+        repo.commit()
+    return updated, dropped
+
+
+# ------------------------------------------------------------------ entry ---
+
+def renumber_folder(
+    folder_path: str,
+    repo: EmailRepository,
+    roots: list[Path],
+    *,
+    dry_run: bool = False,
+) -> RenumberResult:
+    """Give ``folder_path``'s numbered bundles contiguous numbers in date order.
+
+    ``roots`` is the configured ``archive.root_paths``, resolved — a folder that
+    does not sit inside one is refused untouched, so a caller cannot rename its
+    way across the rest of the disk. It is a positional argument rather than an
+    option because a renumber with no root check is never the right call.
+
+    ``dry_run`` computes the whole plan and reports the same map without
+    renaming anything or touching the index.
+    """
+    resolved, refusal = resolve_under_roots(folder_path, roots)
+    normalised = os.path.normpath(folder_path)
+    if resolved is None:
+        logger.warning("Refusing to renumber %r: %s", normalised, refusal)
+        return RenumberResult(
+            folder_path=normalised, dry_run=dry_run, refused=refusal
+        )
+
+    try:
+        groups, prefixes, skipped = _parse_folder(normalised)
+    except OSError as exc:
+        logger.error("Cannot list %r: %s", normalised, exc)
+        return RenumberResult(
+            folder_path=normalised, dry_run=dry_run, refused=REFUSED_UNREADABLE
+        )
+
+    result = RenumberResult(
+        folder_path=normalised, dry_run=dry_run, skipped=skipped
+    )
+    if not groups:
+        logger.info("Nothing numbered in %r; leaving it alone", normalised)
+        return result
+
+    indexed = {r.filename.lower(): r for r in repo.find_in_folder(normalised)}
+    ordered = _order(_build_bundles(normalised, groups, prefixes, indexed))
+
+    base = min(int(number) for number in groups)
+    last = base + len(ordered) - 1
+    if last > 999:
+        raise RenumberError(
+            f"{len(ordered)} bundles from {base:03d} would need a four-digit "
+            "sequence number; this folder cannot be renumbered in place"
+        )
+
+    moves, mapped, unchanged = _plan(normalised, ordered, base)
+    result.renamed = mapped
+    result.bundles = len(ordered)
+    result.unchanged = unchanged
+    result.files_renamed = len(moves)
+    result.first_number = f"{base:03d}"
+    result.last_number = f"{last:03d}"
+
+    if dry_run:
+        logger.info(
+            "Renumber (dry run) of %r: %d bundle(s), %d would change, "
+            "%d file(s) would be renamed.",
+            normalised, result.bundles, len(mapped), len(moves),
+        )
+        return result
+
+    if moves:
+        _rename(normalised, moves)
+        result.index_rows_updated, result.index_rows_dropped = _reindex(
+            moves, indexed, repo
+        )
+
+    logger.info(
+        "Renumbered %r: %d bundle(s) now %s–%s, %d changed, %d file(s) renamed, "
+        "%d index row(s) updated, %d stale row(s) dropped.",
+        normalised, result.bundles, result.first_number, result.last_number,
+        len(mapped), len(moves), result.index_rows_updated,
+        result.index_rows_dropped,
+    )
+    return result

--- a/email_archiver/scanner/scanner.py
+++ b/email_archiver/scanner/scanner.py
@@ -98,6 +98,81 @@ def _message_id(msg: object) -> str:
     return normalize_message_id(raw)
 
 
+def _date_sent(msg: object) -> str:
+    """The mail's sent date as an ISO-8601 string, or ``""`` when there is none.
+
+    The one spelling of this conversion: the index stores what this returns, and
+    a renumber that has to fall back to the file (a ``.msg`` archived since the
+    last scan) reads it back through the same function, so an ordering never
+    depends on which of the two paths supplied the date.
+    """
+    raw = getattr(msg, "date", None)
+    if not raw:
+        return ""
+    try:
+        return raw.isoformat() if isinstance(raw, datetime) else str(raw)
+    except Exception:  # pragma: no cover - defensive, a date that will not render
+        return ""
+
+
+def _attachment_names(msg: object) -> tuple[str, ...]:
+    """The original filenames of the attachments the ``.msg`` carries.
+
+    Used to tell whose attachment a file on disk is when one sequence number
+    ended up carrying two mails; see ``renumber``. Long filename first, short
+    as the fallback — the same order Outlook itself prefers. An attachment that
+    raises (an embedded message, a signed blob) is skipped rather than taking
+    the read down: a partial list only weakens the match, it never corrupts it.
+    """
+    names: list[str] = []
+    try:
+        attachments = msg.attachments
+    except Exception:
+        return ()
+    for attachment in attachments:
+        try:
+            name = getattr(attachment, "longFilename", None) or getattr(
+                attachment, "shortFilename", None
+            )
+        except Exception:
+            continue
+        if name:
+            names.append(str(name))
+    return tuple(names)
+
+
+@dataclass(frozen=True)
+class MsgFacts:
+    """What a ``.msg`` says about itself when the index has not been told yet."""
+
+    date_sent: str
+    message_id: str
+    attachment_names: tuple[str, ...]
+
+
+def read_msg_facts(file_path: str) -> MsgFacts | None:
+    """Read a ``.msg``'s sent date, Message-ID and attachment names in one open.
+
+    The fallback path for :mod:`email_archiver.renumber`: a file archived since
+    the last scan has no index row, and ordering it by "unknown" would put it
+    somewhere arbitrary. Returns ``None`` — logged — when the file cannot be
+    read at all, which the caller treats as an unknown date rather than as a
+    reason to abandon the folder.
+    """
+    try:
+        with extract_msg.Message(file_path) as msg:
+            return MsgFacts(
+                date_sent=_date_sent(msg),
+                message_id=_message_id(msg),
+                attachment_names=_attachment_names(msg),
+            )
+    except (InvalidFileFormatError, UnrecognizedMSGTypeError) as exc:
+        logger.debug("Skipping unreadable .msg %s: %s", file_path, exc)
+    except Exception as exc:
+        logger.warning("Unexpected error reading %s: %s", file_path, exc)
+    return None
+
+
 def _extract_msg_metadata(
     file_path: str, body_preview_len: int
 ) -> dict[str, object] | None:
@@ -112,22 +187,12 @@ def _extract_msg_metadata(
             recipients = _safe_str(msg.to)
             body = _safe_str(msg.body)[:body_preview_len]
 
-            date_sent = ""
-            if msg.date:
-                try:
-                    if isinstance(msg.date, datetime):
-                        date_sent = msg.date.isoformat()
-                    else:
-                        date_sent = str(msg.date)
-                except Exception:
-                    pass
-
             return {
                 "subject": subject,
                 "sender": sender,
                 "recipients": recipients,
                 "body_preview": body,
-                "date_sent": date_sent,
+                "date_sent": _date_sent(msg),
                 "flag_status": _flag_status(msg),
                 "message_id": _message_id(msg),
             }

--- a/main_batch.py
+++ b/main_batch.py
@@ -1,24 +1,28 @@
 """
-Headless batch entry point – plan / apply / revert the whole Outlook Inbox.
+Headless batch entry point – plan / apply / revert / renumber, over JSON.
 
 Meant to be spawned as a subprocess by another local app (task-os), never used
 interactively: every verb prints exactly one JSON document on stdout, logs to
 the usual log file and to stderr, and never opens a window.
 
     python main_batch.py plan --candidates 5 > plan.json
-    python main_batch.py apply --decisions decisions.json
-    python main_batch.py revert --items revert.json
+    python main_batch.py apply --decisions decisions.json [--renumber]
+    python main_batch.py revert --items revert.json [--renumber]
+    python main_batch.py renumber --folder "<a folder>" [--dry-run]
 
 Exit codes:
     0  the run completed and stdout carries its document — individual mails may
        still have failed, each with its own `error` inside the document
-    2  the run could not start: no config, unreadable input, or Outlook
-       unreachable. stdout carries `{"error": {"code", "message"}}` instead
+    2  the run could not start: no config, unreadable input, a folder outside
+       the archive roots, or Outlook unreachable. stdout carries
+       `{"error": {"code", "message"}}` instead
 
-Why a separate process rather than a library call: every verb drives Outlook
-over COM, and a COM modal (the address-book security prompt, a profile chooser)
-blocks whatever thread it is raised on. Spawning this with a timeout means such
-a prompt hangs *this* process, which the caller can kill, and never the caller.
+Why a separate process rather than a library call: the Inbox verbs drive
+Outlook over COM, and a COM modal (the address-book security prompt, a profile
+chooser) blocks whatever thread it is raised on. Spawning this with a timeout
+means such a prompt hangs *this* process, which the caller can kill, and never
+the caller. ``renumber`` is the exception that proves the rule: it reads a
+folder and the index and touches no COM at all, so it never starts Outlook.
 """
 from __future__ import annotations
 
@@ -123,11 +127,34 @@ def _build_parser() -> argparse.ArgumentParser:
         "--decisions", required=True,
         help="JSON file: [{message_id, folder_path, date_prefix}, ...]",
     )
+    p_apply.add_argument(
+        "--renumber", action="store_true",
+        help="Afterwards, renumber every destination folder this run wrote "
+             "into and report the old-to-new map under `renumbered`.",
+    )
 
     p_revert = sub.add_parser("revert", help="Undo an apply: delete files, move back.")
     p_revert.add_argument(
         "--items", required=True,
         help="JSON file: [{message_id, files: [...]}, ...]",
+    )
+    p_revert.add_argument(
+        "--renumber", action="store_true",
+        help="Afterwards, close the gaps in every folder this run deleted from "
+             "and report the old-to-new map under `renumbered`.",
+    )
+
+    p_renumber = sub.add_parser(
+        "renumber",
+        help="Renumber one folder into date order and print the old-to-new map.",
+    )
+    p_renumber.add_argument(
+        "--folder", required=True,
+        help="The folder to renumber. Must be inside archive.root_paths.",
+    )
+    p_renumber.add_argument(
+        "--dry-run", action="store_true",
+        help="Report the same map without renaming anything.",
     )
     return parser
 
@@ -163,6 +190,18 @@ def main(argv: list[str] | None = None) -> int:
     if verb == "plan" and args.candidates < 1:
         return _fail(verb, ERROR_BAD_INPUT, "--candidates must be at least 1")
 
+    if verb == "renumber":
+        # No Outlook, no COM: this verb only reads a folder and the index.
+        document = batch.renumber(cfg, args.folder, dry_run=args.dry_run)
+        if document["renumber_refused"]:
+            refusal = document["renumber_refused"][0]
+            return _fail(
+                verb, ERROR_BAD_INPUT,
+                f"{refusal['folder_path']}: {refusal['reason']}",
+            )
+        _emit(document)
+        return EXIT_OK
+
     try:
         import pythoncom  # noqa: PLC0415
     except ImportError as exc:
@@ -184,9 +223,9 @@ def main(argv: list[str] | None = None) -> int:
         if verb == "plan":
             document = batch.plan(client, cfg, candidates=args.candidates)
         elif verb == "apply":
-            document = batch.apply(client, cfg, payload)
+            document = batch.apply(client, cfg, payload, renumber=args.renumber)
         else:
-            document = batch.revert(client, cfg, payload)
+            document = batch.revert(client, cfg, payload, renumber=args.renumber)
     finally:
         pythoncom.CoUninitialize()
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import pytest
 
 from email_archiver import batch
+from email_archiver import renumber as renumber_module
 from email_archiver.archiver import archiver as archiver_module
 from email_archiver.database.models import init_db
 from email_archiver.database.repository import EmailRecord, EmailRepository
@@ -35,6 +36,7 @@ from email_archiver.outlook.client import (
     with_category,
     without_category,
 )
+from email_archiver.scanner.scanner import MsgFacts
 
 
 # --------------------------------------------------------------- fake COM ---
@@ -1066,3 +1068,219 @@ def test_the_error_document_carries_a_code_and_the_same_envelope():
     assert doc["verb"] == "plan"
     assert doc["schema_version"] == batch.SCHEMA_VERSION
     assert doc["error"] == {"code": "outlook_unavailable", "message": "nope"}
+
+
+# --------------------------------------------------------------- renumber ---
+
+def test_apply_without_the_flag_reports_no_renumber_keys_at_all(cfg, archive_root):
+    """The flag is opt-in: without it the document is byte-for-byte what a
+    consumer built against before this shipped."""
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([_mail("a@example.invalid", "Untouched")])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ])
+
+    assert "renumbered" not in doc
+    assert "renumber_refused" not in doc
+
+
+def test_apply_with_renumber_puts_an_older_mail_in_its_date_position(
+    cfg, archive_root, monkeypatch
+):
+    """The reported case: a mail filed into a folder after a correction takes
+    `max + 1` even though it is older than what is already there.
+
+    The mail `apply` just wrote has no index row yet — nothing has scanned it —
+    so its date comes from the file. Outlook writes a real .msg there and
+    extract-msg reads it; the fake client writes a placeholder, so the read is
+    faked here too rather than silently degrading to "unknown date".
+    """
+    monkeypatch.setattr(
+        renumber_module, "read_msg_facts",
+        lambda path: MsgFacts("2026-03-14T09:00:00+01:00", "a@example.invalid", ()),
+    )
+    dest = archive_root / "Project Alpha"
+    dest.mkdir(parents=True)
+    newer = dest / "001 - Already filed.msg"
+    newer.write_text("synthetic .msg", encoding="utf-8")
+
+    conn = init_db(cfg["database"]["path"])
+    EmailRepository(conn).upsert_email(EmailRecord(
+        file_path=str(newer),
+        folder_path=str(dest),
+        filename=newer.name,
+        subject="Already filed",
+        date_sent="2026-03-20T09:00:00+01:00",
+        file_mtime=1.0,
+        message_id="already@example.invalid",
+    ))
+    conn.commit()
+    conn.close()
+
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "Older one", sent=datetime(2026, 3, 14, 9, 0)),
+    ])
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+    ], renumber=True)
+
+    assert doc["results"][0]["ok"] is True
+    # It went in as 002 and came out as 001; the mail already there moved up.
+    assert sorted(p.name for p in dest.iterdir()) == [
+        "001 - Older one.msg", "002 - Already filed.msg",
+    ]
+    assert doc["renumber_refused"] == []
+    moved = {
+        Path(e["from"]).name: (Path(e["to"]).name, e["message_id"])
+        for e in doc["renumbered"][str(dest)]
+    }
+    assert moved == {
+        "001 - Already filed.msg": (
+            "002 - Already filed.msg", "already@example.invalid",
+        ),
+        "002 - Older one.msg": ("001 - Older one.msg", "a@example.invalid"),
+    }
+
+
+def test_apply_with_renumber_lists_each_destination_folder_once(cfg, archive_root):
+    dest = archive_root / "Project Alpha"
+    other = archive_root / "Project Beta"
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "One", sent=datetime(2026, 3, 14, 9, 0)),
+        _mail("b@example.invalid", "Two", sent=datetime(2026, 3, 15, 9, 0)),
+        _mail("c@example.invalid", "Three", sent=datetime(2026, 3, 16, 9, 0)),
+    ])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(dest)},
+        {"message_id": "b@example.invalid", "folder_path": str(dest)},
+        {"message_id": "c@example.invalid", "folder_path": str(other)},
+    ], renumber=True)
+
+    assert sorted(doc["renumbered"]) == sorted([str(dest), str(other)])
+
+
+def test_apply_with_renumber_refuses_a_folder_outside_the_archive_roots(
+    cfg, tmp_path
+):
+    """`apply` can file anywhere the caller points it — the renumber that
+    follows may not."""
+    outside = tmp_path / "not-the-archive"
+    client = FakeOutlookClient([_mail("a@example.invalid", "Elsewhere")])
+
+    doc = batch.apply(client, cfg, [
+        {"message_id": "a@example.invalid", "folder_path": str(outside)},
+    ], renumber=True)
+
+    assert doc["results"][0]["ok"] is True
+    assert doc["renumbered"] == {}
+    assert doc["renumber_refused"] == [
+        {"folder_path": str(outside), "reason": batch.REFUSED_OUTSIDE_ROOTS}
+    ]
+
+
+def test_revert_with_renumber_closes_the_gap_it_just_made(cfg, archive_root):
+    dest = archive_root / "Project Alpha"
+    client = FakeOutlookClient([
+        _mail("a@example.invalid", "First", sent=datetime(2026, 3, 14, 9, 0)),
+        _mail("b@example.invalid", "Second", sent=datetime(2026, 3, 15, 9, 0)),
+        _mail("c@example.invalid", "Third", sent=datetime(2026, 3, 16, 9, 0)),
+    ])
+    applied = batch.apply(client, cfg, [
+        {"message_id": mid, "folder_path": str(dest)}
+        for mid in ("a@example.invalid", "b@example.invalid", "c@example.invalid")
+    ])
+    for result in applied["results"]:
+        _index_archived_file(
+            cfg, result, message_id=result["message_id"],
+            subject=Path(result["files"][0]).stem,
+        )
+    assert sorted(p.name for p in dest.iterdir()) == [
+        "001 - First.msg", "002 - Second.msg", "003 - Third.msg",
+    ]
+
+    doc = batch.revert(client, cfg, [
+        {"message_id": "b@example.invalid", "files": applied["results"][1]["files"]},
+    ], renumber=True)
+
+    assert doc["results"][0]["ok"] is True
+    assert sorted(p.name for p in dest.iterdir()) == [
+        "001 - First.msg", "002 - Third.msg",
+    ]
+    entry = doc["renumbered"][str(dest)][0]
+    assert Path(entry["from"]).name == "003 - Third.msg"
+    assert Path(entry["to"]).name == "002 - Third.msg"
+    assert doc["renumber_refused"] == []
+
+
+def test_revert_with_renumber_ignores_a_folder_it_deleted_nothing_from(
+    cfg, archive_root
+):
+    """No delete, no gap: a refused or already-missing file must not drag a
+    whole folder through a renumber it did not need."""
+    dest = archive_root / "Project Alpha"
+    dest.mkdir(parents=True)
+    (dest / "003 - Untouched.msg").write_text("synthetic .msg", encoding="utf-8")
+
+    doc = batch.revert(FakeOutlookClient([]), cfg, [
+        {"message_id": "a@example.invalid",
+         "files": [str(dest / "009 - never existed.msg")]},
+    ], renumber=True)
+
+    assert doc["results"][0]["missing"]
+    assert doc["renumbered"] == {}
+    assert sorted(p.name for p in dest.iterdir()) == ["003 - Untouched.msg"]
+
+
+def test_the_renumber_verb_reports_the_map_and_a_dry_run_changes_nothing(
+    cfg, archive_root
+):
+    dest = archive_root / "Project Alpha"
+    dest.mkdir(parents=True)
+    for name in ("001 - one.msg", "003 - three.msg"):
+        (dest / name).write_text("synthetic .msg", encoding="utf-8")
+
+    conn = init_db(cfg["database"]["path"])
+    repo = EmailRepository(conn)
+    for name, date_sent in (
+        ("001 - one.msg", "2026-01-01T09:00:00+01:00"),
+        ("003 - three.msg", "2026-01-03T09:00:00+01:00"),
+    ):
+        repo.upsert_email(EmailRecord(
+            file_path=str(dest / name), folder_path=str(dest), filename=name,
+            subject=name, date_sent=date_sent, file_mtime=1.0,
+            message_id=f"{name}@example.invalid",
+        ))
+    conn.commit()
+    conn.close()
+
+    planned = batch.renumber(cfg, str(dest), dry_run=True)
+    assert planned["verb"] == "renumber"
+    assert planned["schema_version"] == batch.SCHEMA_VERSION
+    assert planned["dry_run"] is True
+    assert planned["counts"]["bundles"] == 2
+    assert planned["counts"]["renamed"] == 1
+    assert sorted(p.name for p in dest.iterdir()) == [
+        "001 - one.msg", "003 - three.msg",
+    ]
+
+    done = batch.renumber(cfg, str(dest))
+    assert done["renumbered"] == planned["renumbered"]
+    assert done["counts"]["index_rows_updated"] == 1
+    assert sorted(p.name for p in dest.iterdir()) == [
+        "001 - one.msg", "002 - three.msg",
+    ]
+
+
+def test_the_renumber_verb_refuses_a_folder_outside_the_archive_roots(cfg, tmp_path):
+    outside = tmp_path / "not-the-archive"
+    outside.mkdir()
+
+    doc = batch.renumber(cfg, str(outside))
+
+    assert doc["renumbered"] == {}
+    assert doc["renumber_refused"] == [
+        {"folder_path": str(outside), "reason": batch.REFUSED_OUTSIDE_ROOTS}
+    ]

--- a/tests/test_renumber.py
+++ b/tests/test_renumber.py
@@ -1,0 +1,543 @@
+"""Tests for renumbering a folder into date order (issue #61).
+
+The sequence number in an archive folder is meant to read as the chronological
+order of the mails in it, and two normal batch operations break that: a
+``revert`` leaves a hole, and an ``apply`` always takes ``max + 1`` even for a
+mail older than everything already filed. ``renumber_folder`` is the repair, and
+what it returns is an interface — another local app stores ``.msg`` paths and
+heals them from that map — so these tests pin the map's shape as much as the
+renames on disk.
+
+Everything on screen here is synthetic: no real folder name, address or subject.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from email_archiver import renumber as renumber_module
+from email_archiver.database.models import init_db
+from email_archiver.database.repository import EmailRecord, EmailRepository
+from email_archiver.paths import REFUSED_OUTSIDE_ROOTS
+from email_archiver.renumber import renumber_folder
+from email_archiver.scanner.scanner import MsgFacts
+
+
+# -------------------------------------------------------------- fixtures ----
+
+@pytest.fixture
+def archive_root(tmp_path) -> Path:
+    root = tmp_path / "archive"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def roots(archive_root) -> list[Path]:
+    return [archive_root.resolve()]
+
+
+@pytest.fixture
+def folder(archive_root) -> Path:
+    target = archive_root / "Project Alpha"
+    target.mkdir()
+    return target
+
+
+@pytest.fixture
+def repo(tmp_path):
+    conn = init_db(tmp_path / "emails.db")
+    try:
+        yield EmailRepository(conn)
+    finally:
+        conn.close()
+
+
+def _write(folder: Path, name: str) -> Path:
+    path = folder / name
+    path.write_text(f"synthetic {name}", encoding="utf-8")
+    return path
+
+
+def _index(
+    repo: EmailRepository,
+    folder: Path,
+    name: str,
+    date_sent: str,
+    message_id: str = "",
+) -> None:
+    """Put one row in the index, the way a scan would have."""
+    repo.upsert_email(EmailRecord(
+        file_path=str(folder / name),
+        folder_path=str(folder),
+        filename=name,
+        subject=Path(name).stem,
+        date_sent=date_sent,
+        file_mtime=1.0,
+        message_id=(
+            message_id
+            or f"{Path(name).stem}@example.invalid".replace(" ", "-")
+        ),
+    ))
+    repo.commit()
+
+
+def _seed(repo: EmailRepository, folder: Path, mails: dict[str, str]) -> None:
+    """Write and index a whole folder: ``{filename: date_sent}``."""
+    for name, date_sent in mails.items():
+        _write(folder, name)
+        if date_sent:
+            _index(repo, folder, name, date_sent)
+
+
+def _names(folder: Path) -> list[str]:
+    return sorted(p.name for p in folder.iterdir())
+
+
+# ------------------------------------------------------------ the basics ----
+
+def test_a_gap_left_by_a_revert_closes(repo, folder, roots):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+        "004 - four.msg": "2026-01-04T09:00:00+01:00",
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert result.refused is None
+    assert _names(folder) == ["001 - one.msg", "002 - three.msg", "003 - four.msg"]
+    assert result.first_number == "001"
+    assert result.last_number == "003"
+    assert result.bundles == 3
+    assert result.unchanged == 1
+
+
+def test_an_older_mail_filed_last_moves_to_its_date_position(repo, folder, roots):
+    """The apply half of the problem: a mail archived after a correction took
+    ``max + 1`` even though it is older than what was already there."""
+    _seed(repo, folder, {
+        "001 - first.msg": "2026-01-01T09:00:00+01:00",
+        "002 - third.msg": "2026-01-03T09:00:00+01:00",
+        "003 - latecomer.msg": "2026-01-02T09:00:00+01:00",
+    })
+
+    renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "001 - first.msg", "002 - latecomer.msg", "003 - third.msg",
+    ]
+
+
+def test_attachments_follow_their_mail(repo, folder, roots):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+    })
+    _write(folder, "003 - report.pdf")
+    _write(folder, "003 - notes.docx")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "001 - one.msg", "002 - notes.docx", "002 - report.pdf", "002 - three.msg",
+    ]
+    entry = result.renamed[0]
+    assert Path(entry["from"]).name == "003 - three.msg"
+    assert Path(entry["to"]).name == "002 - three.msg"
+    assert sorted(Path(old).name for old, _ in entry["attachments"]) == [
+        "003 - notes.docx", "003 - report.pdf",
+    ]
+    assert sorted(Path(new).name for _, new in entry["attachments"]) == [
+        "002 - notes.docx", "002 - report.pdf",
+    ]
+
+
+def test_the_map_reports_only_what_changed(repo, folder, roots):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert [Path(e["from"]).name for e in result.renamed] == ["003 - three.msg"]
+    assert set(result.renamed[0]) == {"from", "to", "message_id", "attachments"}
+    assert result.renamed[0]["message_id"] == "003---three@example.invalid"
+
+
+def test_a_folder_already_in_order_is_not_touched(repo, folder, roots):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "002 - two.msg": "2026-01-02T09:00:00+01:00",
+    })
+    before = {p.name: p.stat().st_mtime_ns for p in folder.iterdir()}
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert result.renamed == []
+    assert result.files_renamed == 0
+    assert {p.name: p.stat().st_mtime_ns for p in folder.iterdir()} == before
+
+
+# --------------------------------------------------------------- the base ---
+
+def test_the_base_is_the_folders_lowest_existing_number(repo, folder, roots):
+    """A "part 2" folder continues another folder's sequence: renumbering it
+    from 001 would destroy exactly the fact its numbers carry."""
+    _seed(repo, folder, {
+        "079 - one.msg": "2026-01-01T09:00:00+01:00",
+        "081 - two.msg": "2026-01-02T09:00:00+01:00",
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == ["079 - one.msg", "080 - two.msg"]
+    assert (result.first_number, result.last_number) == ("079", "080")
+
+
+# ------------------------------------------------------- both name forms ----
+
+def test_each_file_keeps_its_own_dated_or_undated_form(repo, folder, roots):
+    _seed(repo, folder, {
+        "2026-01-01 - 001 - dated.msg": "2026-01-01T09:00:00+01:00",
+        "003 - undated.msg": "2026-01-03T09:00:00+01:00",
+        "2026-01-05 - 005 - dated too.msg": "2026-01-05T09:00:00+01:00",
+    })
+    _write(folder, "2026-01-05 - 005 - attached.pdf")
+
+    renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "002 - undated.msg",
+        "2026-01-01 - 001 - dated.msg",
+        "2026-01-05 - 003 - attached.pdf",
+        "2026-01-05 - 003 - dated too.msg",
+    ]
+
+
+# ------------------------------------------------------ two on one number ---
+
+def test_two_mails_sharing_one_number_end_up_distinct(repo, folder, roots):
+    _seed(repo, folder, {
+        "087 - earlier.msg": "2026-09-08T16:00:00+02:00",
+        "087 - later.msg": "2026-09-09T05:00:00+02:00",
+        "088 - after.msg": "2026-09-09T13:00:00+02:00",
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "087 - earlier.msg", "088 - later.msg", "089 - after.msg",
+    ]
+    assert result.bundles == 3
+    assert (result.first_number, result.last_number) == ("087", "089")
+
+
+def test_a_shared_numbers_attachments_go_to_the_mail_that_carries_them(
+    repo, folder, roots, monkeypatch
+):
+    """Filenames cannot say whose attachment is whose, so each candidate mail
+    is asked what it carries. Getting this wrong files somebody's diagrams
+    under an unrelated mail — silently, and permanently."""
+    _seed(repo, folder, {
+        "087 - earlier.msg": "2026-09-08T16:00:00+02:00",
+        "087 - later.msg": "2026-09-09T05:00:00+02:00",
+    })
+    _write(folder, "087 - diagram one.png")
+
+    facts = {
+        "087 - earlier.msg": MsgFacts("", "", ("image001.png",)),
+        "087 - later.msg": MsgFacts("", "", ("diagram one.png",)),
+    }
+    monkeypatch.setattr(
+        renumber_module, "read_msg_facts",
+        lambda path: facts.get(os.path.basename(path)),
+    )
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "087 - earlier.msg", "088 - diagram one.png", "088 - later.msg",
+    ]
+    entry = result.renamed[0]
+    assert Path(entry["to"]).name == "088 - later.msg"
+    assert entry["attachments_placed"] == renumber_module.PLACED_BY_MSG
+
+
+def test_an_unclaimed_attachment_follows_the_earlier_mail_and_says_so(
+    repo, folder, roots, monkeypatch
+):
+    """A guess that is reported is recoverable; a silent one is not."""
+    _seed(repo, folder, {
+        "087 - earlier.msg": "2026-09-08T16:00:00+02:00",
+        "087 - later.msg": "2026-09-09T05:00:00+02:00",
+    })
+    _write(folder, "087 - orphan.png")
+    monkeypatch.setattr(
+        renumber_module, "read_msg_facts", lambda path: MsgFacts("", "", ())
+    )
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "087 - earlier.msg", "087 - orphan.png", "088 - later.msg",
+    ]
+    # The earlier mail did not move, so only the split-off mail is in the map;
+    # the fallback is still reported, on the bundle that was split.
+    assert result.renamed[0]["attachments_placed"] == (
+        renumber_module.PLACED_BY_FALLBACK
+    )
+
+
+# ------------------------------------------------- unnumbered and orphans ---
+
+def test_a_file_with_no_sequence_prefix_is_left_alone_and_reported(
+    repo, folder, roots
+):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+    })
+    _write(folder, "052a - hand named.msg")
+    _write(folder, "notes.txt")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert sorted(result.skipped) == ["052a - hand named.msg", "notes.txt"]
+    assert (folder / "052a - hand named.msg").exists()
+    assert (folder / "notes.txt").exists()
+
+
+def test_a_number_with_no_mail_holds_its_slot(repo, folder, roots):
+    """An attachment whose mail was deleted by hand still owns its number. Left
+    behind, it would end up sharing a number with an unrelated mail."""
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "004 - four.msg": "2026-01-04T09:00:00+01:00",
+    })
+    _write(folder, "002 - stranded.docx")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "001 - one.msg", "002 - stranded.docx", "003 - four.msg",
+    ]
+    assert result.bundles == 3
+    # The stranded file has no mail, so its map entry carries no .msg path —
+    # a consumer healing stored .msg paths has nothing to heal for it.
+    assert [e for e in result.renamed if e["from"] is None] == []
+
+
+def test_an_undated_bundle_keeps_its_position_rather_than_moving_to_one_end(
+    repo, folder, roots
+):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+    })
+    # Indexed with no date and unreadable as a .msg: genuinely unknown.
+    _write(folder, "002 - undatable.msg")
+
+    renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "001 - one.msg", "002 - undatable.msg", "003 - three.msg",
+    ]
+
+
+# -------------------------------------------------------------- dry run -----
+
+def test_dry_run_changes_nothing_and_returns_the_same_map(repo, folder, roots):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+    })
+    _write(folder, "003 - report.pdf")
+    before = _names(folder)
+
+    planned = renumber_folder(str(folder), repo, roots, dry_run=True)
+
+    assert planned.dry_run is True
+    assert _names(folder) == before
+    assert planned.index_rows_updated == 0
+    assert repo.find_in_folder(str(folder))[0].filename == "001 - one.msg"
+
+    done = renumber_folder(str(folder), repo, roots)
+
+    assert done.renamed == planned.renamed
+    assert (done.first_number, done.last_number) == (
+        planned.first_number, planned.last_number
+    )
+    assert _names(folder) != before
+
+
+# --------------------------------------------------------------- the index --
+
+def test_the_index_rows_follow_the_renames(repo, folder, roots):
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - three.msg": "2026-01-03T09:00:00+01:00",
+        "004 - four.msg": "2026-01-04T09:00:00+01:00",
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert result.index_rows_updated == 2
+    rows = {r.filename: r.file_path for r in repo.find_in_folder(str(folder))}
+    assert set(rows) == {"001 - one.msg", "002 - three.msg", "003 - four.msg"}
+    assert all(Path(path).exists() for path in rows.values())
+    # The row is updated, not replaced: its Message-ID is still the mail's.
+    assert repo.find_path_by_message_id("003---three@example.invalid") == str(
+        folder / "002 - three.msg"
+    )
+
+
+def test_two_mails_swapping_names_do_not_break_the_unique_index(repo, folder, roots):
+    """Regression: ``emails.file_path`` is UNIQUE, and two mails on one thread
+    carry the same subject, so a reorder hands one of them the exact path the
+    other still holds. Updating the rows one at a time raised ``IntegrityError``
+    and rolled the whole index update back — *after* the files on disk had been
+    renamed, leaving the index describing a folder that no longer existed.
+    Found the first time this ran against a real folder.
+    """
+    _write(folder, "001 - thread.msg")
+    _write(folder, "002 - thread.msg")
+    _index(repo, folder, "001 - thread.msg", "2026-01-02T09:00:00+01:00",
+           message_id="later@example.invalid")
+    _index(repo, folder, "002 - thread.msg", "2026-01-01T09:00:00+01:00",
+           message_id="earlier@example.invalid")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    # The names are the same two; which mail is behind each one swapped.
+    assert _names(folder) == ["001 - thread.msg", "002 - thread.msg"]
+    assert result.index_rows_updated == 2
+    assert (folder / "001 - thread.msg").read_text(encoding="utf-8") == (
+        "synthetic 002 - thread.msg"
+    )
+    assert repo.find_path_by_message_id("earlier@example.invalid") == str(
+        folder / "001 - thread.msg"
+    )
+    assert repo.find_path_by_message_id("later@example.invalid") == str(
+        folder / "002 - thread.msg"
+    )
+
+
+def test_a_stale_row_on_a_name_a_rename_takes_is_dropped_not_left_lying(
+    repo, folder, roots
+):
+    """A row whose file is gone keeps pointing at a name another mail is about
+    to be given. Left alone it breaks the UNIQUE constraint, and were it to
+    survive it would describe somebody else's mail."""
+    _seed(repo, folder, {
+        "001 - one.msg": "2026-01-01T09:00:00+01:00",
+        "003 - thread.msg": "2026-01-03T09:00:00+01:00",
+    })
+    # Indexed, but its file is long gone — and 003 is headed for exactly its name.
+    _index(repo, folder, "002 - thread.msg", "2026-01-02T09:00:00+01:00",
+           message_id="gone@example.invalid")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert result.index_rows_dropped == 1
+    assert result.index_rows_updated == 1
+    rows = {r.filename for r in repo.find_in_folder(str(folder))}
+    assert rows == {"001 - one.msg", "002 - thread.msg"} == set(_names(folder))
+    assert repo.find_path_by_message_id("gone@example.invalid") is None
+
+
+def test_a_renamed_mail_that_was_never_indexed_is_not_an_error(repo, folder, roots):
+    _seed(repo, folder, {"001 - one.msg": "2026-01-01T09:00:00+01:00"})
+    _write(folder, "003 - never scanned.msg")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == ["001 - one.msg", "002 - never scanned.msg"]
+    assert result.index_rows_updated == 0
+
+
+# --------------------------------------------------------------- refusals ---
+
+def test_a_folder_outside_the_archive_roots_is_refused_untouched(
+    repo, tmp_path, roots
+):
+    outsider = tmp_path / "not-the-archive"
+    outsider.mkdir()
+    (outsider / "003 - precious.msg").write_text("do not touch me", encoding="utf-8")
+
+    result = renumber_folder(str(outsider), repo, roots)
+
+    assert result.refused == REFUSED_OUTSIDE_ROOTS
+    assert result.renamed == []
+    assert _names(outsider) == ["003 - precious.msg"]
+
+
+def test_a_traversal_out_of_an_archive_root_is_refused(repo, archive_root, roots,
+                                                       tmp_path):
+    outsider = tmp_path / "not-the-archive"
+    outsider.mkdir()
+    sneaky = str(archive_root / ".." / "not-the-archive")
+
+    assert renumber_folder(sneaky, repo, roots).refused == REFUSED_OUTSIDE_ROOTS
+
+
+def test_an_unreadable_folder_is_refused_rather_than_reported_empty(repo, roots,
+                                                                    archive_root):
+    missing = archive_root / "never created"
+
+    result = renumber_folder(str(missing), repo, roots)
+
+    assert result.refused == renumber_module.REFUSED_UNREADABLE
+    assert result.renamed == []
+
+
+def test_a_folder_with_nothing_numbered_is_a_no_op_not_a_refusal(repo, folder,
+                                                                 roots):
+    _write(folder, "notes.txt")
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert result.refused is None
+    assert result.bundles == 0
+    assert result.skipped == ["notes.txt"]
+
+
+# ------------------------------------------------------ the rename itself ---
+
+def test_a_whole_run_shifting_down_by_one_never_collides(repo, folder, roots):
+    """Every target name is the name of the file next to it — which is why the
+    renames go through a placeholder first."""
+    _seed(repo, folder, {
+        f"{n:03d} - mail.msg": f"2026-01-{n:02d}T09:00:00+01:00"
+        for n in range(2, 12)
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [f"{n:03d} - mail.msg" for n in range(2, 12)]
+    assert result.files_renamed == 0, "already contiguous from its own base"
+
+    (folder / "002 - mail.msg").unlink()
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [f"{n:03d} - mail.msg" for n in range(3, 12)]
+    assert result.files_renamed == 0, "the base moved with the folder's lowest"
+
+
+def test_closing_an_interior_gap_shifts_the_whole_tail_down(repo, folder, roots):
+    _seed(repo, folder, {
+        f"{n:03d} - mail {n}.msg": f"2026-01-{n:02d}T09:00:00+01:00"
+        for n in [1, 2, 4, 5, 6, 7]
+    })
+
+    result = renumber_folder(str(folder), repo, roots)
+
+    assert _names(folder) == [
+        "001 - mail 1.msg", "002 - mail 2.msg", "003 - mail 4.msg",
+        "004 - mail 5.msg", "005 - mail 6.msg", "006 - mail 7.msg",
+    ]
+    assert result.files_renamed == 4
+    assert not [p for p in folder.iterdir() if p.name.startswith("~")]


### PR DESCRIPTION
| SHA | What | Why |
|---|---|---|
| `0ed2132` | `renumber_folder`, the `renumber` verb, `--renumber` on `apply`/`revert`, `paths.py` | The sequence number is meant to read as the mails' order, and `revert`/`apply` break it |
| `eb38415` | Report an unindexed folder; log a stopped rename from either phase; README note on `apply --renumber`'s own `files` | Three non-blocking points from the independent review — a silent zero-row lookup, a missing recovery log, an under-documented interaction |

## Summary

The `NNN` prefix in an archive folder is meant to read as the order the mails happened. Two ordinary batch operations break that, and neither is a bug in how a single mail is archived: `revert` deletes a bundle and leaves a hole, and `apply` always allocates `max + 1`, so a mail filed into a folder after a correction lands last even when it is older than everything already there.

This adds a **renumber** operation that repairs a folder, and returns the old → new map so the consumer can heal the `.msg` paths it stored.

- **`email_archiver/renumber.py`** — `renumber_folder(folder, repo, roots, *, dry_run=False)`. Orders a folder's numbered bundles by sent date (from the index, falling back to reading the `.msg` for a file archived since the last scan), hands out contiguous numbers from the folder's **own lowest existing number** (a folder that starts at `079` because it continues another folder's sequence keeps starting at `079`), and keeps each file's dated/undated form.
- **The unit is a bundle** — a number and every file carrying it — so an email never parts company with its attachments. A number holding only an attachment (a mail deleted by hand, a document filed into the sequence) still holds its slot rather than being left on a number that now belongs to someone else. A bundle with no readable date keeps its current position instead of being swept to one end.
- **Two mails that ended up sharing one number are split by date**, and their attachments are matched to the right one by asking each `.msg` what attachments it carries — filenames cannot say. An attachment that still cannot be placed follows the earlier mail and the map reports that as `attachments_placed`, because a reported guess is recoverable and a silent one is not.
- **Two-phase renames** through a same-length `~XX` placeholder: closing a gap gives a file the name of the file next to it, and these paths sit near `MAX_PATH`, so the placeholder is the same width as the number it replaces.
- **The index follows the same two phases.** `emails.file_path` is UNIQUE and two mails on one thread share a subject, so a reorder routinely hands one of them the exact path the other still holds. A row left on a name a rename is about to take, whose own file is gone, is dropped and counted separately as `index_rows_dropped`.
- **`main_batch.py renumber --folder <path> [--dry-run]`**, plus **`--renumber` on `apply` and `revert`** (each touched folder renumbered once, after the verb's own work). Without the flag both verbs behave exactly as before and neither key appears. `renumber` touches no Outlook and no COM.
- **`email_archiver/paths.py`** — the `archive.root_paths` guard moves out of `batch.py` so `revert`'s deletes and `renumber`'s renames share one spelling of it rather than two.
- README: the verb, the flag, the ordering rule, the refusals, and the note that the consumer must heal its stored paths from the map. `docs/architecture.mmd` and `.fleet.toml` updated in the same PR.

### Consumer compatibility

`renumbered` is **additive** and `schema_version` stays `1`: a consumer that parses these documents by key reads everything else exactly as before. A folder that could **not** be renumbered is never an empty map in `renumbered` — an empty map means "already in order" — it goes to `renumber_refused` with its reason.

```json
"renumbered": {
  "<folder>": [
    {
      "from": "<folder>\\003 - subject.msg",
      "to":   "<folder>\\002 - subject.msg",
      "message_id": "abc123@mail.example",
      "attachments": [["<folder>\\003 - report.pdf", "<folder>\\002 - report.pdf"]]
    }
  ]
}
```

`from`/`to` are `null` for a bundle with no `.msg`; only bundles that actually changed appear.

## Validation

The gate here is `& .\.venv\Scripts\python.exe -m pytest tests/` — there is **no ruff and no CI workflow in this repo**, so the local suite is the whole gate. No UX surface, no e2e suite, no screenshot manifest, no declared deploy-coverage component (all three helpers report a no-op for this repo).

- [x] **Unit + integration tests** — `pytest tests/`: **168 passed** (136 before; +32 new, 22 in `tests/test_renumber.py` and 10 in `tests/test_batch.py`). Zero failures, zero skips.
- [x] **Reproduction proof for the defect found mid-run.** The first real run renamed the files correctly and then aborted on `sqlite3.IntegrityError: UNIQUE constraint failed: emails.file_path`, leaving the index rolled back and describing a folder that no longer existed. Two regression tests were written for it (`test_two_mails_swapping_names_do_not_break_the_unique_index`, `test_a_stale_row_on_a_name_a_rename_takes_is_dropped_not_left_lying`) and **proven to fail against the pre-fix single-pass update** with that exact error before the two-phase fix was restored.
- [x] **Behavioural verification, real CLI against real folders.** `renumber --dry-run` and `renumber` were run for real on the two folders of the 2026-09-10 case; a second `--dry-run` on a healed folder is a clean no-op (`renamed: 0`), and a folder outside `archive.root_paths` exits `2` with one JSON document, `bad_input: outside_archive_roots`.
- [x] **Independent review** by a fresh agent with no memory of the build — fetched the acceptance criteria itself, read the diff, re-ran the gate independently (168 passed), and re-derived both healed folders read-only from disk + index. Verdict **pass**, no blockers; its three non-blocking nits are all fixed in `eb38415`.

## The heal (acceptance criterion 3)

Counts only, per the issue's public-repo constraint.

| | folder A | folder B |
|---|---|---|
| bundles | 80 | 14 |
| bundles renumbered | 51 | 5 |
| files renamed | 60 | 10 |
| index rows updated | 51 | 2 |
| stale index rows dropped | 0 | 0 |
| final range | `000`–`079`, contiguous | `079`–`092`, contiguous |
| gaps after | none | none |
| numbers carrying more than one `.msg` after | none | none |
| unnumbered files left alone | 1 | 0 |
| leftover `~XX` placeholders | none | none |
| chronological inversions after | 0 | 0 |
| file count before → after | 91 → 91 | 22 → 22 |

Both dry-run maps matched their real-run maps byte for byte, and the map file was kept for the consumer. Folder A's base is `000` rather than `001` because its lowest existing number belongs to a numbered non-`.msg` file — that is the issue's stated rule (contiguous from the folder's lowest existing number), and it is what leaves the folder's oldest numbering untouched. Folder B's shared number was split correctly and its attachments followed the mail that actually carries them (`attachments_placed: matched_to_msg`, not the fallback).

Nothing else in the archive changed: `renumber` renames only inside the one folder it is given (the maps show zero moves leaving the folder) and only updates index rows returned for that folder. Archive-wide, all **18,443** index rows point at a file that exists.

Closes #61


https://claude.ai/code/session_01XY1TW3d8mm8YDZDLqjjEdd
