### PR TITLE
fix: report Outlook/DB failures during batch dispatch as JSON, not a crash

### DIFF
--- a/main_batch.py
+++ b/main_batch.py
@@ -220,12 +220,26 @@ def main(argv: list[str] | None = None) -> int:
         except OutlookUnavailableError as exc:
             return _fail(verb, ERROR_OUTLOOK_UNAVAILABLE, str(exc))
 
-        if verb == "plan":
-            document = batch.plan(client, cfg, candidates=args.candidates)
-        elif verb == "apply":
-            document = batch.apply(client, cfg, payload, renumber=args.renumber)
-        else:
-            document = batch.revert(client, cfg, payload, renumber=args.renumber)
+        try:
+            if verb == "plan":
+                document = batch.plan(client, cfg, candidates=args.candidates)
+            elif verb == "apply":
+                document = batch.apply(client, cfg, payload, renumber=args.renumber)
+            else:
+                document = batch.revert(client, cfg, payload, renumber=args.renumber)
+        except OutlookUnavailableError as exc:
+            # Outlook was up when ensure_running() checked but quit or went
+            # unreachable partway through the walk (client._namespace()).
+            return _fail(verb, ERROR_OUTLOOK_UNAVAILABLE, str(exc))
+        except Exception as exc:
+            # Deliberately broad, mirroring the config-load guard above: once
+            # Outlook has been reached, any other failure during the walk (a
+            # locked or corrupt database, a COM call raising something other
+            # than OutlookUnavailableError) still has to come out as this
+            # process's one JSON document, not as a traceback on stderr with
+            # nothing on stdout, which is what a spawning caller would see as
+            # a crash it cannot classify.
+            return _fail(verb, ERROR_COM_UNAVAILABLE, f"{type(exc).__name__}: {exc}")
     finally:
         pythoncom.CoUninitialize()
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1144,7 +1144,15 @@ def test_apply_with_renumber_puts_an_older_mail_in_its_date_position(
     }
 
 
-def test_apply_with_renumber_lists_each_destination_folder_once(cfg, archive_root):
+def test_apply_with_renumber_lists_each_destination_folder_once(
+    cfg, archive_root, monkeypatch
+):
+    """Two mails filed into the same folder must renumber it once for the
+    whole run, not once per mail — a second pass would reorder what the
+    first pass just fixed. ``doc["renumbered"]`` is keyed by folder path, so
+    it can never show a folder twice however broken the dedupe in
+    ``_unique_folders`` is; only counting the actual ``renumber_folder``
+    calls pins the dedupe itself."""
     dest = archive_root / "Project Alpha"
     other = archive_root / "Project Beta"
     client = FakeOutlookClient([
@@ -1153,12 +1161,22 @@ def test_apply_with_renumber_lists_each_destination_folder_once(cfg, archive_roo
         _mail("c@example.invalid", "Three", sent=datetime(2026, 3, 16, 9, 0)),
     ])
 
+    real_renumber_folder = batch.renumber_folder
+    calls: list[str] = []
+
+    def _counting_renumber_folder(folder_path, *args, **kwargs):
+        calls.append(str(folder_path))
+        return real_renumber_folder(folder_path, *args, **kwargs)
+
+    monkeypatch.setattr(batch, "renumber_folder", _counting_renumber_folder)
+
     doc = batch.apply(client, cfg, [
         {"message_id": "a@example.invalid", "folder_path": str(dest)},
         {"message_id": "b@example.invalid", "folder_path": str(dest)},
         {"message_id": "c@example.invalid", "folder_path": str(other)},
     ], renumber=True)
 
+    assert calls == [str(dest), str(other)]
     assert sorted(doc["renumbered"]) == sorted([str(dest), str(other)])
 
 

--- a/tests/test_renumber.py
+++ b/tests/test_renumber.py
@@ -318,7 +318,7 @@ def test_a_number_with_no_mail_holds_its_slot(repo, folder, roots):
         "001 - one.msg": "2026-01-01T09:00:00+01:00",
         "004 - four.msg": "2026-01-04T09:00:00+01:00",
     })
-    _write(folder, "002 - stranded.docx")
+    _write(folder, "003 - stranded.docx")
 
     result = renumber_folder(str(folder), repo, roots)
 
@@ -326,9 +326,11 @@ def test_a_number_with_no_mail_holds_its_slot(repo, folder, roots):
         "001 - one.msg", "002 - stranded.docx", "003 - four.msg",
     ]
     assert result.bundles == 3
-    # The stranded file has no mail, so its map entry carries no .msg path —
-    # a consumer healing stored .msg paths has nothing to heal for it.
-    assert [e for e in result.renamed if e["from"] is None] == []
+    # The stranded bundle's number does move here (003 -> 002), so its entry
+    # in the map is reached — and being mail-less, it carries no .msg path, a
+    # consumer healing stored .msg paths has nothing to heal for it.
+    stranded_entries = [e for e in result.renamed if e["from"] is None]
+    assert len(stranded_entries) == 1
 
 
 def test_an_undated_bundle_keeps_its_position_rather_than_moving_to_one_end(


### PR DESCRIPTION
## Summary
- Wraps the plan/apply/revert dispatch in `main_batch.py` in the same broad exception guard used for config load, so an Outlook COM failure or a locked/corrupt database mid-run now emits a proper error JSON document (`EXIT_CANNOT_START`) instead of a bare traceback with nothing on stdout.
- Fixes `test_renumber.py`'s stranded-attachment test to seed a fixture where the orphan's number actually moves, so the `from: None` assertion exercises the code path it claims to.
- Fixes `test_batch.py`'s per-folder-dedupe test to count actual `renumber_folder` invocations instead of asserting an unrepresentable property of a dict-keyed result.

## Test plan
- [x] `.venv\Scripts\python.exe -m pytest tests/` — 167 passed

Closes #65