### PR TITLE
chore: remove dead raw_item field and stale path-budget comment

### DIFF
--- a/email_archiver/archiver/archiver.py
+++ b/email_archiver/archiver/archiver.py
@@ -65,10 +65,8 @@ _OL_MSG_FORMAT = 3
 _RE_DATED_PREFIX = re.compile(r"^(\d{4}-\d{2}-\d{2}) - (\d{3}) - ")
 _RE_UNDATED_PREFIX = re.compile(r"^(\d{3}) - ")
 
-# Maximum path length (in chars) the fitted filename must stay within. This is
-# the SAME budget the scanner uses — sourced from config via
-# ``get_max_path_length`` and threaded in through ``EmailArchiver``; see
-# ``config.DEFAULT_MAX_PATH_LENGTH`` for the rationale behind the value.
+# Appended to a filename's stem when it has to be cut to fit the path budget
+# (see ``_fit_filename_to_path``).
 _ELLIPSIS = "..."
 
 # Bound on the attachment de-duplication loop in ``_save_attachments`` — a
@@ -352,7 +350,8 @@ class EmailArchiver:
         Save the email and its attachments to folder_path.
 
         Args:
-            mail_item: Outlook COM MailItem (from OutlookClient.raw_item).
+            mail_item: Outlook COM MailItem, freshly acquired by the caller
+                (COM objects are STA — never cache one across threads).
             folder_path: Absolute path to the destination folder.
             subject: Clean subject string (used for filename).
 

--- a/email_archiver/outlook/client.py
+++ b/email_archiver/outlook/client.py
@@ -38,7 +38,6 @@ class EmailData:
     sender: str = ""
     recipients: str = ""           # semicolon-separated SMTP addresses
     date_sent: datetime | None = None
-    raw_item: Any = None           # the COM MailItem – only used by archiver
 
 
 @dataclass
@@ -441,7 +440,6 @@ class OutlookClient:
                 sender=_get_sender_smtp(item),
                 recipients=_get_recipients_smtp(item),
                 date_sent=_sent_datetime(item),
-                raw_item=item,
             )
 
         except Exception as exc:


### PR DESCRIPTION
## Summary
- Removes `EmailData.raw_item` and its assignment in `OutlookClient` — the COM `MailItem` was written on every scan but never read; the archive dialog deliberately re-acquires the item on the UI thread instead (STA COM objects can't cross threads), and rewords `EmailArchiver.save_email`'s `mail_item` doc to describe that actual caller contract instead of the abandoned `raw_item` path.
- Deletes the stranded max-path-length comment above `_ELLIPSIS` in `archiver.py` — left behind when the budget was unified onto `config.DEFAULT_MAX_PATH_LENGTH` — and replaces it with a one-line pointer to what `_ELLIPSIS` actually is.

## Test plan
- [x] `.venv\Scripts\python.exe -m pytest tests/` — 167 passed

Closes #64